### PR TITLE
Add maxDictionaryRefsInContextMenu to config file

### DIFF
--- a/articleview.cc
+++ b/articleview.cc
@@ -971,7 +971,7 @@ void ArticleView::contextMenuRequested( QPoint const & pos )
   for( QStringList::const_iterator i = ids.constBegin(); i != ids.constEnd();
        ++i, ++refsAdded )
   {
-    if ( refsAdded == 20 )
+    if ( refsAdded == cfg.maxDictionaryRefsInContextMenu )
     {
       // Enough! Or the menu would become too large.
       menu.addAction( new QAction( ".........", &menu ) );

--- a/config.cc
+++ b/config.cc
@@ -666,6 +666,9 @@ Class load() throw( exError )
 
   c.usingSmallIconsInToolbars = ( root.namedItem( "usingSmallIconsInToolbars" ).toElement().text() == "1" );
 
+  if ( !root.namedItem( "maxDictionaryRefsInContextMenu" ).isNull() )
+    c.maxDictionaryRefsInContextMenu = root.namedItem( "maxDictionaryRefsInContextMenu" ).toElement().text().toUShort();
+
   return c;
 }
 
@@ -1195,6 +1198,10 @@ void save( Class const & c ) throw( exError )
 
     opt = dd.createElement( "usingSmallIconsInToolbars" );
     opt.appendChild( dd.createTextNode( c.usingSmallIconsInToolbars ? "1" : "0" ) );
+    root.appendChild( opt );
+
+    opt = dd.createElement( "maxDictionaryRefsInContextMenu" );
+    opt.appendChild( dd.createTextNode( QString::number( c.maxDictionaryRefsInContextMenu ) ) );
     root.appendChild( opt );
   }
 

--- a/config.hh
+++ b/config.hh
@@ -377,8 +377,11 @@ struct Class
 
   bool usingSmallIconsInToolbars;
 
+  unsigned short maxDictionaryRefsInContextMenu;
+
   Class(): lastMainGroupId( 0 ), lastPopupGroupId( 0 ),
-           pinPopupWindow( false ), showingDictBarNames( false ), usingSmallIconsInToolbars( false )
+           pinPopupWindow( false ), showingDictBarNames( false ),
+           usingSmallIconsInToolbars( false ), maxDictionaryRefsInContextMenu( 20 )
   {}
 };
 


### PR DESCRIPTION
Add maxDictionaryRefsInContextMenu to config file to allow to change number of dictionaries in the context menu (Right-click on the definitions frame). Default to 20.
