### PR TITLE
Icons are not shown in various places on Linux

### DIFF
--- a/articleview.cc
+++ b/articleview.cc
@@ -989,6 +989,10 @@ void ArticleView::contextMenuRequested( QPoint const & pos )
                 allDictionaries[ x ]->getIcon(),
                 QString::fromUtf8( allDictionaries[ x ]->getName().c_str() ),
                 &menu );
+        // Force icons in menu on all platfroms,
+        // since without them it will be much harder
+        // to find things.
+        action->setIconVisibleInMenu( true );
 
         menu.addAction( action );
 

--- a/dictionarybar.cc
+++ b/dictionarybar.cc
@@ -94,6 +94,9 @@ void DictionaryBar::contextMenuEvent( QContextMenuEvent * event )
     action->setCheckable( true );
     action->setChecked( (*i)->isChecked() );
     action->setData( QVariant::fromValue( (void *)*i ) );
+    // Force "icon in menu" on all platforms, for
+    // usability reasons.
+    action->setIconVisibleInMenu( true );
   }
 
   if ( !menu.isEmpty() )

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -2005,6 +2005,7 @@ void MainWindow::historyChanged()
     QIcon icon = group ? group->makeIcon() : QIcon();
 
     QAction * action = ui.menuHistory->addAction( icon, i->word );
+    action->setIconVisibleInMenu( true );
 
     action->setData( x );
   }


### PR DESCRIPTION
1. In History menu. Notice that all entries are without pictures (picture should correspond to the flag of the dictionary group).
2. In the context popup menu, all dictionaries are without their icons.

Tested on Ubuntu Linux 10.04, 11.04, Mint 11. Latest GoldenDict.

P.S. Everything is OK on Windows though.
