### PR TITLE
Failure to index a dictionary in UTF-8 format on Windows

### DIFF
--- a/dsl_details.cc
+++ b/dsl_details.cc
@@ -739,7 +739,7 @@ bool DslScanner::readNextLine( wstring & out, size_t & offset ) throw( Ex,
       --leftInOut; // Complements the next decremention
     }
 
-    if ( ( r != Iconv::Success && r != Iconv::NeedMoreOut ) || outBytesLeft )
+    if ( outBytesLeft )
       throw exEncodingError();
 
     --leftInOut;


### PR DESCRIPTION
Here's an example of such dictionary: http://www.multiupload.com/OT6632HYRQ

An attempt to index it leads to "Encoding error" on Windows, while works just fine on Linux.

Patch to follow.
