### PR TITLE
Modified goldendict.pro for Mac OS X

### DIFF
--- a/goldendict.pro
+++ b/goldendict.pro
@@ -90,13 +90,15 @@ unix {
 }
 mac {
     CONFIG += x86 x86_64
-    LIBS += -liconv \
+    LIBS = -lz \
+        -liconv \
         -lvorbisfile \
         -lvorbis \
         -logg \
         -lhunspell-1.3
     INCLUDEPATH += maclibs/include
     LIBS += -Lmaclibs/lib \
+        -L/usr/lib \
         -L/usr/X11/lib
     ICON = icons/macicon.icns
 }


### PR DESCRIPTION
Minor correction: modified goldendict.pro so that it ignores any extra libs installed on the system via Brew/Macports/etc and uses only built-in libs and the ones provided in the 'maclibs' folder.

Signed-off-by: Denis Loginov dloginov@mit.edu
