### PR TITLE
Regression:  Can't go up and down the list of suggestions

### DIFF
--- a/article_maker.cc
+++ b/article_maker.cc
@@ -101,7 +101,7 @@ std::string ArticleMaker::makeHtmlHeader( QString const & word,
             "function processIframeMouseOut() { overIframeId = null; top.focus(); }"
             "function processIframeMouseOver( newId ) { overIframeId = newId; }"
             "function processIframeClick() { if( overIframeId != null ) { overIframeId = overIframeId.replace( 'gdexpandframe-', '' ); gdMakeArticleActive( overIframeId ) } }"
-            "function init() { window.addEventListener('blur', processIframeClick, false); top.focus(); }"
+            "function init() { window.addEventListener('blur', processIframeClick, false); }"
             "window.addEventListener('load', init, false);"
             "</script>";
 

--- a/articlewebview.cc
+++ b/articlewebview.cc
@@ -38,3 +38,20 @@ void ArticleWebView::mouseDoubleClickEvent( QMouseEvent * event )
   }
 
 }
+
+void ArticleWebView::focusInEvent( QFocusEvent * event )
+{
+  QWebView::focusInEvent( event );
+
+  switch( event->reason() )
+  {
+    case Qt::MouseFocusReason:
+    case Qt::TabFocusReason:
+    case Qt::BacktabFocusReason:
+      page()->mainFrame()->evaluateJavaScript("top.focus();");
+      break;
+
+    default:
+      break;
+  }
+}

--- a/articlewebview.hh
+++ b/articlewebview.hh
@@ -38,6 +38,7 @@ protected:
   void mousePressEvent( QMouseEvent * event );
   void mouseReleaseEvent( QMouseEvent * event );
   void mouseDoubleClickEvent( QMouseEvent * event );
+  void focusInEvent( QFocusEvent * event );
 
 private:
 


### PR DESCRIPTION
The recent revision a7cb431c72055273bb9dea9935906e7c287f553c: "Clicking on "...." in the article view's context menu opens the Results Navigation Pane" introduced a regression on Linux, reported here:

http://goldendict.org/forum/viewtopic.php?f=6&t=1210#p5257

Basically, when using up-down arrows in the suggestions list, causes the focus to be moved to the main article view, thus making it impossible to use up-down more than once.
