### PR TITLE
base64 encoded images

### DIFF
--- a/stardict.cc
+++ b/stardict.cc
@@ -336,7 +336,7 @@ string StardictDictionary::handleResource( char type, char const * resource, siz
       string articleText = "<div class=\"sdct_h\">" + string( resource, size ) + "</div>";
 
       return ( QString::fromUtf8( articleText.c_str() )
-               .replace( QRegExp( "(<\\s*img\\s+[^>]*src\\s*=\\s*[\"']*)([^\"']*)", Qt::CaseInsensitive ),
+               .replace( QRegExp( "(<\\s*img\\s+[^>]*src\\s*=\\s*[\"']+)((?!data:)[^\"']*)", Qt::CaseInsensitive ),
                          "\\1bres://" + QString::fromStdString( getId() ) + "/\\2" )
                .toUtf8().data() );
     }


### PR DESCRIPTION
Hi :)

GoldenDict doesn't seem to render base64 encoded images, which is a shame, because that's an extremely convenient way to work with images, and webkit ought to handle it just fine, right?

Here is an example that I was trying to use (rare Chinese character not in unicode):

```
<img style="height:1em;" alt="[這-言+囉]" src="data:image/png;base64,
iVBORw0KGgoAAAANSUhEUgAAADIAAAArCAMAAAANOCvQAAAABlBMVEUAAAAAAAClZ7nPAAAAAXRS
TlMAQObYZgAAAM9JREFUeNrdlVEOgDAIQ+H+lzauS+qABvwzEtENeUZYnfYxcx/kJMu33yKZWZHl
JDJ0vPiab8esYvg6I8ROxDHHAOG2TxxNELOMGE0jzHORGBFGd6R8tkYQ7pGwlGUJHIS2aUGpjgnF
ZGTCpPJDvg/WxVgF5nOElwFyHx3CAtYQ1PZe/TBZS5T5md0j/DwYgIsCQscoMS0znOFAmC7Lpxwo
e40EBYV+e4sgwva1SFCnRLxE1LZRyuhE9Gpq01vyK8K41oXJbrmw5lf4VPWf7QLgqQLWfz5bOAAA
AABJRU5ErkJggg==
" />
```

It might even come out here:

<img style="height:1em;" alt="[這-言+囉]" src="data:image/png;base64,
iVBORw0KGgoAAAANSUhEUgAAADIAAAArCAMAAAANOCvQAAAABlBMVEUAAAAAAAClZ7nPAAAAAXRS
TlMAQObYZgAAAM9JREFUeNrdlVEOgDAIQ+H+lzauS+qABvwzEtENeUZYnfYxcx/kJMu33yKZWZHl
JDJ0vPiab8esYvg6I8ROxDHHAOG2TxxNELOMGE0jzHORGBFGd6R8tkYQ7pGwlGUJHIS2aUGpjgnF
ZGTCpPJDvg/WxVgF5nOElwFyHx3CAtYQ1PZe/TBZS5T5md0j/DwYgIsCQscoMS0znOFAmC7Lpxwo
e40EBYV+e4sgwva1SFCnRLxE1LZRyuhE9Gpq01vyK8K41oXJbrmw5lf4VPWf7QLgqQLWfz5bOAAA
AABJRU5ErkJggg==
" />

Thanks for considering this!

Edit:  is it just a case of modifying the regex in `stardict.cc` (~ ln. 338) so that these don't get processed?

Edit:  it seems it is!  If I do a proper fork and pull request, would you be likely to accept it?
