### PR TITLE
Tajik Language Support

### DIFF
--- a/locale/tg_TJ.ts
+++ b/locale/tg_TJ.ts
@@ -1,0 +1,3354 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.0" language="tg_TJ" sourcelanguage="en_US">
+<context>
+    <name>About</name>
+    <message>
+        <location filename="../about.ui" line="17"/>
+        <source>About</source>
+        <translation>Дар бораи барнома</translation>
+    </message>
+    <message>
+        <location filename="../about.ui" line="51"/>
+        <source>GoldenDict dictionary lookup program, version </source>
+        <translation>Луғати GoldenDict, версияи </translation>
+    </message>
+    <message>
+        <location filename="../about.ui" line="73"/>
+        <source>(c) 2008-2012 Konstantin Isakov (ikm@goldendict.org)</source>
+        <translation>(c) 2008-2012 Константин Исаков (ikm@goldendict.org)</translation>
+    </message>
+    <message>
+        <location filename="../about.ui" line="83"/>
+        <source>Licensed under GNU GPLv3 or later</source>
+        <translation>Иҷозатномаи GNU GPLv3 ё навтар</translation>
+    </message>
+    <message>
+        <location filename="../about.ui" line="97"/>
+        <source>Credits:</source>
+        <translation>Рӯйхати тарҷумонҳо:</translation>
+    </message>
+    <message>
+        <location filename="../about.cc" line="16"/>
+        <source>[Unknown]</source>
+        <translation>[Номаълум]</translation>
+    </message>
+</context>
+<context>
+    <name>ArticleMaker</name>
+    <message>
+        <location filename="../article_maker.cc" line="119"/>
+        <source>No translation for &lt;b&gt;%1&lt;/b&gt; was found in group &lt;b&gt;%2&lt;/b&gt;.</source>
+        <translation>Ягон тарҷума барои &lt;b&gt;%1&lt;/b&gt; дар гурӯҳи &lt;b&gt;%2&lt;/b&gt; ёфт нашуд.</translation>
+    </message>
+    <message>
+        <location filename="../article_maker.cc" line="124"/>
+        <source>No translation was found in group &lt;b&gt;%1&lt;/b&gt;.</source>
+        <translation>Ягон тарҷума дар гурӯҳи &lt;b&gt;%1&lt;/b&gt; ёфт нашуд.</translation>
+    </message>
+    <message>
+        <location filename="../article_maker.cc" line="143"/>
+        <source>Welcome!</source>
+        <translation>Хуш омадед!</translation>
+    </message>
+    <message>
+        <location filename="../article_maker.cc" line="145"/>
+        <source>&lt;h3 align=&quot;center&quot;&gt;Welcome to &lt;b&gt;GoldenDict&lt;/b&gt;!&lt;/h3&gt;&lt;p&gt;To start working with the program, first visit &lt;b&gt;Edit|Dictionaries&lt;/b&gt; to add some directory paths where to search for the dictionary files, set up various Wikipedia sites or other sources, adjust dictionary order or create dictionary groups.&lt;p&gt;And then you&apos;re ready to look up your words! You can do that in this window by using a pane to the left, or you can &lt;a href=&quot;Working with popup&quot;&gt;look up words from other active applications&lt;/a&gt;. &lt;p&gt;To customize program, check out the available preferences at &lt;b&gt;Edit|Preferences&lt;/b&gt;. All settings there have tooltips, be sure to read them if you are in doubt about anything.&lt;p&gt;Should you need further help, have any questions, suggestions or just wonder what the others think, you are welcome at the program&apos;s &lt;a href=&quot;http://goldendict.org/forum/&quot;&gt;forum&lt;/a&gt;.&lt;p&gt;Check program&apos;s &lt;a href=&quot;http://goldendict.org/&quot;&gt;website&lt;/a&gt; for the updates. &lt;p&gt;(c) 2008-2012 Konstantin Isakov. Licensed under GPLv3 or later.</source>
+        <translation>&lt;h3 align=&quot;center&quot;&gt;Хуш омадед ба луғати &lt;b&gt;GoldenDict&lt;/b&gt;!&lt;/h3&gt;&lt;p&gt;Барои оғози кор бо луғат, пеш аз ҳама ба &lt;b&gt;Танзимот|Луғатҳо&lt;/b&gt; гузаред ва файлҳои луғатҳои лозимиро илова кунед, сайтҳои Wikipedia ё сайтҳои дигарро насб кунед, тартиби луғатҳоро таъйин кунед ё гурӯҳҳои луғатро эҷод кунед.&lt;p&gt;Баъд аз ин шумо метавонед калимаҳоро тарҷума кунед! Шумо метавонед калимаҳоро бо истифодаи лавҳаи чапи ин тиреза тарҷума кунед, ё шумо метавонед &lt;a href=&quot;Working with popup&quot;&gt;калимаҳоро дар барномаҳои кушодашудаи дигар тарҷума кунед&lt;/a&gt;. &lt;p&gt;Барои насб кардани танзимоти шахсӣ, хусусиятҳои дастрасиро дар &lt;b&gt;Танзимот|Хусусиятҳо&lt;/b&gt; истифода баред. Ҳамаи танзимоти ин барнома дорои маслиҳат мебошанд. Агар ягон мушкилӣ дошта бошед, мутмаин шавед, ки онҳоро хонед.&lt;p&gt;Барои маълумоти муфассал, гирифтани кумак, ҷавобу саволҳо, маслиҳатҳо ё ҳалли масъалаҳои дигар, шумо метавонед &lt;a href=&quot;http://goldendict.org/forum/&quot;&gt;форуми луғатро&lt;/a&gt; истифода баред.&lt;p&gt;Барои гирифтани навсозиҳои барнома &lt;a href=&quot;http://goldendict.org/&quot;&gt;вебсайти луғатро&lt;/a&gt; дидан кунед. &lt;p&gt;(c) 2008-2012 Константин Исаков. Иҷозатномаи GPLv3 ё навтар.</translation>
+    </message>
+    <message>
+        <location filename="../article_maker.cc" line="161"/>
+        <source>Working with popup</source>
+        <translation>Тарҷума бо тирезаи пайдошаванда</translation>
+    </message>
+    <message>
+        <location filename="../article_maker.cc" line="163"/>
+        <source>&lt;h3 align=&quot;center&quot;&gt;Working with the popup&lt;/h3&gt;To look up words from other active applications, you would need to first activate the &lt;i&gt;&quot;Scan popup functionality&quot;&lt;/i&gt; in &lt;b&gt;Preferences&lt;/b&gt;, and then enable it at any time either by triggering the &apos;Popup&apos; icon above, or by clicking the tray icon down below with your right mouse button and choosing so in the menu you&apos;ve popped. </source>
+        <translation>&lt;h3 align=&quot;center&quot;&gt;Тарҷума бо тирезаи пайдошаванда&lt;/h3&gt;Барои тарҷума кардани калимаҳо дар барномаҳои дигар, пеш аз ҳама шумо бояд &lt;i&gt;&quot;Хусусияти тарҷумаи пайдошавандаро&quot;&lt;/i&gt; дар &lt;b&gt;Хусусиятҳо&lt;/b&gt; фаъол кунед. Дар оянда шумо метавонед ин хусусиятро ба воситаи зеркунии тугмаи &apos;Тарҷумаи пайдошаванда&apos; фаъол кунед, ё шумо метавонед ин хусусиятро бо зеркунии нишонаи панел аз менюи пайдошуда фаъол кунед. </translation>
+    </message>
+    <message>
+        <location filename="../article_maker.cc" line="170"/>
+        <source>Then just stop the cursor over the word you want to look up in another application, and a window would pop up which would describe it to you.</source>
+        <translation>Баъд аз фаъол кардани хусусияти тарҷумаи пайдошаванда курсори мушро ба болои калимаи дилхоҳ ҷойгир кунед, ва тиреза бо тарҷумаҳо бояд барои шумо пайдо шавад.</translation>
+    </message>
+    <message>
+        <location filename="../article_maker.cc" line="173"/>
+        <source>Then just select any word you want to look up in another application by your mouse (double-click it or swipe it with mouse with the button pressed), and a window would pop up which would describe the word to you.</source>
+        <translation>Баъд аз фаъол кардани хусусияти тарҷумаи пайдошаванда калимаи дилхоҳро дар барномаи дигар бо курсори муш интихоб кунед (ба калимаи дилхоҳ пахши дубора бо курсори муш кунед) ва тиреза бо тарҷумаҳо бояд барои шумо пайдо шавад.</translation>
+    </message>
+    <message>
+        <location filename="../article_maker.cc" line="250"/>
+        <source>(untitled)</source>
+        <translation>(беном)</translation>
+    </message>
+</context>
+<context>
+    <name>ArticleRequest</name>
+    <message>
+        <location filename="../article_maker.cc" line="412"/>
+        <source>From </source>
+        <translation>Аз </translation>
+    </message>
+    <message>
+        <location filename="../article_maker.cc" line="425"/>
+        <source>Query error: %1</source>
+        <translation>Хатои дархост: %1</translation>
+    </message>
+    <message>
+        <location filename="../article_maker.cc" line="524"/>
+        <source>Close words: </source>
+        <translation>Калимаҳои наздик: </translation>
+    </message>
+    <message>
+        <location filename="../article_maker.cc" line="595"/>
+        <source>Compound expressions: </source>
+        <translation>Ифодаҳои алоқадор: </translation>
+    </message>
+    <message>
+        <location filename="../article_maker.cc" line="623"/>
+        <source>Individual words: </source>
+        <translation>Калимаҳои шахсӣ: </translation>
+    </message>
+</context>
+<context>
+    <name>ArticleView</name>
+    <message>
+        <location filename="../articleview.ui" line="14"/>
+        <source>Form</source>
+        <translation>Шакл</translation>
+    </message>
+    <message>
+        <location filename="../articleview.ui" line="36"/>
+        <source>about:blank</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../articleview.ui" line="65"/>
+        <source>x</source>
+        <translation>x</translation>
+    </message>
+    <message>
+        <location filename="../articleview.ui" line="79"/>
+        <source>Find:</source>
+        <translation>Ҷустуҷӯ:</translation>
+    </message>
+    <message>
+        <location filename="../articleview.ui" line="89"/>
+        <source>&amp;Previous</source>
+        <translation>&amp;Пешина</translation>
+    </message>
+    <message>
+        <location filename="../articleview.ui" line="106"/>
+        <source>&amp;Next</source>
+        <translation>&amp;Навбатӣ</translation>
+    </message>
+    <message>
+        <location filename="../articleview.ui" line="113"/>
+        <source>Ctrl+G</source>
+        <translation>Ctrl+G</translation>
+    </message>
+    <message>
+        <location filename="../articleview.ui" line="126"/>
+        <source>&amp;Case Sensitive</source>
+        <translation>&amp;Аломатҳои хурду калон</translation>
+    </message>
+    <message>
+        <location filename="../articleview.ui" line="133"/>
+        <source>Highlight &amp;all</source>
+        <translation>Ҳамаашро ҷу&amp;до кунед</translation>
+    </message>
+    <message>
+        <location filename="../articleview.cc" line="606"/>
+        <source>Resource</source>
+        <translation>Манбаъ</translation>
+    </message>
+    <message>
+        <location filename="../articleview.cc" line="611"/>
+        <source>Audio</source>
+        <translation>Аудио</translation>
+    </message>
+    <message>
+        <location filename="../articleview.cc" line="621"/>
+        <source>Definition: %1</source>
+        <translation>Маъно: %1</translation>
+    </message>
+    <message>
+        <location filename="../articleview.cc" line="792"/>
+        <location filename="../articleview.cc" line="822"/>
+        <location filename="../articleview.cc" line="831"/>
+        <location filename="../articleview.cc" line="1210"/>
+        <location filename="../articleview.cc" line="1228"/>
+        <location filename="../articleview.cc" line="1238"/>
+        <source>GoldenDict</source>
+        <translation>Луғати GoldenDict</translation>
+    </message>
+    <message>
+        <location filename="../articleview.cc" line="792"/>
+        <source>The referenced resource doesn&apos;t exist.</source>
+        <translation>Манбаъи ишорашуда вуҷуд надорад.</translation>
+    </message>
+    <message>
+        <location filename="../articleview.cc" line="832"/>
+        <source>The referenced audio program doesn&apos;t exist.</source>
+        <translation>Барномаи аудиоии ишорашуда вуҷуд надорад.</translation>
+    </message>
+    <message>
+        <location filename="../articleview.cc" line="963"/>
+        <source>&amp;Open Link</source>
+        <translation>&amp;Пайвандро кушоед</translation>
+    </message>
+    <message>
+        <location filename="../articleview.cc" line="969"/>
+        <source>Open Link in New &amp;Tab</source>
+        <translation>Пайвандро дар &amp;варақаи нав кушоед</translation>
+    </message>
+    <message>
+        <location filename="../articleview.cc" line="976"/>
+        <source>Open Link in &amp;External Browser</source>
+        <translation>Пайвандро дар &amp;браузер кушоед</translation>
+    </message>
+    <message>
+        <location filename="../articleview.cc" line="989"/>
+        <source>&amp;Look up &quot;%1&quot;</source>
+        <translation>&quot;%1&quot;-ро &amp;дарёфт кунед</translation>
+    </message>
+    <message>
+        <location filename="../articleview.cc" line="997"/>
+        <source>Look up &quot;%1&quot; in &amp;New Tab</source>
+        <translation>&quot;%1&quot;-ро дар варақаи &amp;нав дарёфт кунед</translation>
+    </message>
+    <message>
+        <location filename="../articleview.cc" line="1012"/>
+        <source>Look up &quot;%1&quot; in %2</source>
+        <translation>&quot;%1&quot;-ро дар %2 дарёфт кунед</translation>
+    </message>
+    <message>
+        <location filename="../articleview.cc" line="1020"/>
+        <source>Look up &quot;%1&quot; in %2 in &amp;New Tab</source>
+        <translation>&quot;%1&quot;-ро дар %2 дар варақаи &amp;нав дарёфт кунед</translation>
+    </message>
+    <message>
+        <location filename="../articleview.cc" line="1167"/>
+        <source>Playing a non-WAV file</source>
+        <translation>Файли ғайри-WAV иҷро шуда истодааст</translation>
+    </message>
+    <message>
+        <location filename="../articleview.cc" line="1168"/>
+        <source>To enable playback of files different than WAV, please go to Edit|Preferences, choose the Audio tab and select &quot;Play via DirectShow&quot; there.</source>
+        <translation>Барои фаъол кардани иҷрои файлҳои ғайри WAV, лутфан ба Танзимот|Хусусиятҳо гузаред, варақаи аудиоро интихоб кунед ва имконоти &quot;Ба воситаи DirectShow иҷро кунед&quot;-ро дар он ҷо интихоб кунед.</translation>
+    </message>
+    <message>
+        <location filename="../articleview.cc" line="1210"/>
+        <source>Failed to run a player to play sound file: %1</source>
+        <translation>Барои иҷрои файли аудиоӣ кушоиши плеер қатъ карда шуд: %1</translation>
+    </message>
+    <message>
+        <location filename="../articleview.cc" line="1228"/>
+        <source>Failed to create temporary file.</source>
+        <translation>Эҷодкунии файли муваққатӣ қатъ карда шуд.</translation>
+    </message>
+    <message>
+        <location filename="../articleview.cc" line="1239"/>
+        <source>Failed to auto-open resource file, try opening manually: %1.</source>
+        <translation>Кушоиши файл ба таври худкор қатъ карда шуд, кӯшиш кунед, ки онро ба таври дастӣ кушоед: %1.</translation>
+    </message>
+    <message>
+        <location filename="../articleview.cc" line="1262"/>
+        <source>WARNING: %1</source>
+        <translation>ОГОҲӢ: %1</translation>
+    </message>
+    <message>
+        <location filename="../articleview.cc" line="1262"/>
+        <source>The referenced resource failed to download.</source>
+        <translation>Боргирии манбаъи ишорашуда қатъ карда шуд.</translation>
+    </message>
+</context>
+<context>
+    <name>DictGroupWidget</name>
+    <message>
+        <location filename="../dictgroupwidget.ui" line="14"/>
+        <source>Form</source>
+        <translation>Шакл</translation>
+    </message>
+    <message>
+        <location filename="../dictgroupwidget.ui" line="37"/>
+        <source>Group icon:</source>
+        <translation>Нишонаи гурӯҳ:</translation>
+    </message>
+    <message>
+        <location filename="../dictgroupwidget.ui" line="85"/>
+        <source>Shortcut:</source>
+        <translation>Миёнбур:</translation>
+    </message>
+    <message>
+        <location filename="../groups_widgets.cc" line="35"/>
+        <source>None</source>
+        <translation>Ҳеҷ чиз</translation>
+    </message>
+    <message>
+        <location filename="../groups_widgets.cc" line="40"/>
+        <source>From file...</source>
+        <translation>Аз файли...</translation>
+    </message>
+    <message>
+        <location filename="../groups_widgets.cc" line="80"/>
+        <source>Choose a file to use as group icon</source>
+        <translation>Файлро барои истифода ҳамчун нишонаи гурӯҳ интихоб кунед</translation>
+    </message>
+    <message>
+        <location filename="../groups_widgets.cc" line="82"/>
+        <source>Images</source>
+        <translation>Тасвирҳо</translation>
+    </message>
+    <message>
+        <location filename="../groups_widgets.cc" line="83"/>
+        <source>All files</source>
+        <translation>Ҳамаи файлҳо</translation>
+    </message>
+    <message>
+        <location filename="../groups_widgets.cc" line="90"/>
+        <source>Error</source>
+        <translation>Хато</translation>
+    </message>
+    <message>
+        <location filename="../groups_widgets.cc" line="90"/>
+        <source>Can&apos;t read the specified image file.</source>
+        <translation>Файли тасвири интихобшуда кушода нашуд.</translation>
+    </message>
+</context>
+<context>
+    <name>DictGroupsWidget</name>
+    <message>
+        <location filename="../groups_widgets.cc" line="572"/>
+        <source>Confirmation</source>
+        <translation>Тасдиқ</translation>
+    </message>
+    <message>
+        <location filename="../groups_widgets.cc" line="573"/>
+        <source>Are you sure you want to generate a set of groups based on language pairs?</source>
+        <translation>Шумо мутмаин ҳастед, ки мехоҳед дастаи гурӯҳҳоро дар асоси ҷуфтҳои забонӣ эҷод кунед?</translation>
+    </message>
+</context>
+<context>
+    <name>DictListModel</name>
+    <message>
+        <location filename="../groups_widgets.cc" line="188"/>
+        <source>%1 entries</source>
+        <translation>%1 вуруд</translation>
+    </message>
+</context>
+<context>
+    <name>DictionaryBar</name>
+    <message>
+        <location filename="../dictionarybar.cc" line="13"/>
+        <source>Dictionary Bar</source>
+        <translation>Лавҳаи луғат</translation>
+    </message>
+    <message>
+        <location filename="../dictionarybar.cc" line="107"/>
+        <source>Edit this group</source>
+        <translation>Гурӯҳи зеринро таҳрир кунед</translation>
+    </message>
+</context>
+<context>
+    <name>EditDictionaries</name>
+    <message>
+        <location filename="../editdictionaries.ui" line="14"/>
+        <source>Dictionaries</source>
+        <translation>Луғатҳо</translation>
+    </message>
+    <message>
+        <location filename="../editdictionaries.cc" line="41"/>
+        <source>&amp;Sources</source>
+        <translation>&amp;Манбаъҳо</translation>
+    </message>
+    <message>
+        <location filename="../editdictionaries.cc" line="42"/>
+        <location filename="../editdictionaries.cc" line="217"/>
+        <source>&amp;Dictionaries</source>
+        <translation>&amp;Луғатҳо</translation>
+    </message>
+    <message>
+        <location filename="../editdictionaries.cc" line="43"/>
+        <location filename="../editdictionaries.cc" line="220"/>
+        <source>&amp;Groups</source>
+        <translation>&amp;Гурӯҳҳо</translation>
+    </message>
+    <message>
+        <location filename="../editdictionaries.cc" line="101"/>
+        <source>Sources changed</source>
+        <translation>Манбаъ иваз шуд</translation>
+    </message>
+    <message>
+        <location filename="../editdictionaries.cc" line="102"/>
+        <source>Some sources were changed. Would you like to accept the changes?</source>
+        <translation>Баъзе манбаъҳо иваз карда шудаанд. Шумо мехоҳед ин таъғиротро қабул кунед?</translation>
+    </message>
+    <message>
+        <location filename="../editdictionaries.cc" line="105"/>
+        <source>Accept</source>
+        <translation>Қабул кунед</translation>
+    </message>
+    <message>
+        <location filename="../editdictionaries.cc" line="107"/>
+        <source>Cancel</source>
+        <translation>Бекор кунед</translation>
+    </message>
+</context>
+<context>
+    <name>ExternalViewer</name>
+    <message>
+        <location filename="../externalviewer.cc" line="49"/>
+        <source>the viewer program name is empty</source>
+        <translation>номи нишондиҳандаи барнома холӣ аст</translation>
+    </message>
+</context>
+<context>
+    <name>Forvo::ForvoArticleRequest</name>
+    <message>
+        <location filename="../forvo.cc" line="217"/>
+        <source>XML parse error: %1 at %2,%3</source>
+        <translation>Хатои таҳлили XML: %1 дар %2,%3</translation>
+    </message>
+    <message>
+        <location filename="../forvo.cc" line="293"/>
+        <source>Added %1</source>
+        <translation>%1 илова шуд</translation>
+    </message>
+    <message>
+        <location filename="../forvo.cc" line="296"/>
+        <source>by</source>
+        <translation>аз</translation>
+    </message>
+    <message>
+        <location filename="../forvo.cc" line="300"/>
+        <source>Male</source>
+        <translation>Мард</translation>
+    </message>
+    <message>
+        <location filename="../forvo.cc" line="300"/>
+        <source>Female</source>
+        <translation>Зан</translation>
+    </message>
+    <message>
+        <location filename="../forvo.cc" line="302"/>
+        <source>from</source>
+        <translation>аз</translation>
+    </message>
+    <message>
+        <location filename="../forvo.cc" line="340"/>
+        <source>Go to Edit|Dictionaries|Sources|Forvo and apply for our own API key to make this error disappear.</source>
+        <translation>Ба Танзимот|Луғатҳо|Манбаъҳо||Forvo гузаред ва барои ҳал кардани ин хато калиди API-и худро татбиқ кунед.</translation>
+    </message>
+</context>
+<context>
+    <name>GermanTranslit</name>
+    <message>
+        <location filename="../german.cc" line="48"/>
+        <source>German Transliteration</source>
+        <translation>Транслитератсияи олмонӣ</translation>
+    </message>
+</context>
+<context>
+    <name>GreekTranslit</name>
+    <message>
+        <location filename="../greektranslit.cc" line="839"/>
+        <source>Greek Transliteration</source>
+        <translation>Транслитератсияи юнонӣ</translation>
+    </message>
+</context>
+<context>
+    <name>GroupComboBox</name>
+    <message>
+        <location filename="../groupcombobox.cc" line="12"/>
+        <source>Choose a Group (Alt+G)</source>
+        <translation>Гурӯҳро интихоб кунед (Alt+G)</translation>
+    </message>
+</context>
+<context>
+    <name>GroupSelectorWidget</name>
+    <message>
+        <location filename="../groupselectorwidget.ui" line="13"/>
+        <source>Form</source>
+        <translation>Шакл</translation>
+    </message>
+    <message>
+        <location filename="../groupselectorwidget.ui" line="19"/>
+        <source>Look in</source>
+        <translation>Ҷустуҷӯ дар</translation>
+    </message>
+</context>
+<context>
+    <name>Groups</name>
+    <message>
+        <location filename="../groups.ui" line="22"/>
+        <source>Dictionaries available:</source>
+        <translation>Луғатҳои дастрас:</translation>
+    </message>
+    <message>
+        <location filename="../groups.ui" line="61"/>
+        <source>Add selected dictionaries to group (Ins)</source>
+        <translation>Луғатҳои интихобшударо ба гурӯҳ илова кунед (гутмаи Ins)</translation>
+    </message>
+    <message>
+        <location filename="../groups.ui" line="64"/>
+        <source>&gt;</source>
+        <translation>&gt;</translation>
+    </message>
+    <message>
+        <location filename="../groups.ui" line="67"/>
+        <source>Ins</source>
+        <translation>Тугмаи Ins</translation>
+    </message>
+    <message>
+        <location filename="../groups.ui" line="86"/>
+        <source>Remove selected dictionaries from group (Del)</source>
+        <translation>Луғатҳои интихобшударо аз гурӯҳ тоза кунед (гутмаи Del)</translation>
+    </message>
+    <message>
+        <location filename="../groups.ui" line="89"/>
+        <source>&lt;</source>
+        <translation>&lt;</translation>
+    </message>
+    <message>
+        <location filename="../groups.ui" line="92"/>
+        <source>Del</source>
+        <translation>Тутмаи Del</translation>
+    </message>
+    <message>
+        <location filename="../groups.ui" line="116"/>
+        <source>Groups:</source>
+        <translation>Гурӯҳҳо:</translation>
+    </message>
+    <message>
+        <location filename="../groups.ui" line="130"/>
+        <source>Tab 2</source>
+        <translation>Варақаи 2</translation>
+    </message>
+    <message>
+        <location filename="../groups.ui" line="140"/>
+        <source>Create new dictionary group</source>
+        <translation>Гурӯҳи луғати навро эҷод кунед</translation>
+    </message>
+    <message>
+        <location filename="../groups.ui" line="143"/>
+        <source>&amp;Add group</source>
+        <translation>&amp;Гурӯҳро илова кунед</translation>
+    </message>
+    <message>
+        <location filename="../groups.ui" line="150"/>
+        <source>Create language-based groups</source>
+        <translation>Гурӯҳи забондонро эҷод кунед</translation>
+    </message>
+    <message>
+        <location filename="../groups.ui" line="153"/>
+        <source>Auto groups</source>
+        <translation>Гурӯҳҳои худкор</translation>
+    </message>
+    <message>
+        <location filename="../groups.ui" line="160"/>
+        <source>Rename current dictionary group</source>
+        <translation>Номи гурӯҳи луғати ҷориро иваз кунед</translation>
+    </message>
+    <message>
+        <location filename="../groups.ui" line="163"/>
+        <source>Re&amp;name group</source>
+        <translation>&amp;Номи гурӯҳро иваз кунед</translation>
+    </message>
+    <message>
+        <location filename="../groups.ui" line="170"/>
+        <source>Remove current dictionary group</source>
+        <translation>Гурӯҳи луғати ҷориро тоза кунед</translation>
+    </message>
+    <message>
+        <location filename="../groups.ui" line="173"/>
+        <source>&amp;Remove group</source>
+        <translation>&amp;Гурӯҳро тоза кунед</translation>
+    </message>
+    <message>
+        <location filename="../groups.ui" line="180"/>
+        <source>Remove all dictionary groups</source>
+        <translation>Ҳамаи гурӯҳҳои луғатро тоза кунед</translation>
+    </message>
+    <message>
+        <location filename="../groups.ui" line="183"/>
+        <location filename="../groups.cc" line="145"/>
+        <source>Remove all groups</source>
+        <translation>Ҳамаи гурӯҳҳоро тоза кунед</translation>
+    </message>
+    <message>
+        <location filename="../groups.ui" line="194"/>
+        <source>Drag&amp;drop dictionaries to and from the groups, move them inside the groups, reorder the groups using your mouse.</source>
+        <translation>Луғатҳоро аз гурӯҳҳо ва ба гурӯҳҳо &amp;кашида монед, онҳоро дар гурӯҳҳо таҳвил кунед ва тартиби гурӯҳҳоро ба воситаи муш иваз кунед.</translation>
+    </message>
+    <message>
+        <location filename="../groups.cc" line="94"/>
+        <source>Add group</source>
+        <translation>Гурӯҳро илова кунед</translation>
+    </message>
+    <message>
+        <location filename="../groups.cc" line="95"/>
+        <source>Give a name for the new group:</source>
+        <translation>Ба гурӯҳи нав номро гузоред:</translation>
+    </message>
+    <message>
+        <location filename="../groups.cc" line="120"/>
+        <source>Rename group</source>
+        <translation>Номи гурӯҳро иваз кунед</translation>
+    </message>
+    <message>
+        <location filename="../groups.cc" line="121"/>
+        <source>Give a new name for the group:</source>
+        <translation>Ба гурӯҳ номи навро гузоред:</translation>
+    </message>
+    <message>
+        <location filename="../groups.cc" line="132"/>
+        <source>Remove group</source>
+        <translation>Гурӯҳро тоза кунед</translation>
+    </message>
+    <message>
+        <location filename="../groups.cc" line="133"/>
+        <source>Are you sure you want to remove the group &lt;b&gt;%1&lt;/b&gt;?</source>
+        <translation>Шумо мутмаин ҳастед, ки мехоҳед гурӯҳи &lt;b&gt;%1&lt;/b&gt;-ро тоза кунед?</translation>
+    </message>
+    <message>
+        <location filename="../groups.cc" line="146"/>
+        <source>Are you sure you want to remove all the groups?</source>
+        <translation>Шумо мутмаин ҳастед, ки мехоҳед ҳамаи гурӯҳҳоро тоза кунед?</translation>
+    </message>
+</context>
+<context>
+    <name>Hunspell</name>
+    <message>
+        <location filename="../hunspell.cc" line="217"/>
+        <source>Spelling suggestions: </source>
+        <translation>Пешниҳоди санҷиши калима: </translation>
+    </message>
+    <message>
+        <location filename="../hunspell.cc" line="751"/>
+        <source>%1 Morphology</source>
+        <translation>Морфологияи %1</translation>
+    </message>
+</context>
+<context>
+    <name>HunspellDictsModel</name>
+    <message>
+        <location filename="../sources.cc" line="1075"/>
+        <source>Enabled</source>
+        <translation>Фаъолшуда</translation>
+    </message>
+    <message>
+        <location filename="../sources.cc" line="1077"/>
+        <source>Name</source>
+        <translation>Ном</translation>
+    </message>
+</context>
+<context>
+    <name>Initializing</name>
+    <message>
+        <location filename="../initializing.ui" line="16"/>
+        <source>GoldenDict - Initializing</source>
+        <translation>Омодасозии GoldenDict</translation>
+    </message>
+    <message>
+        <location filename="../initializing.ui" line="22"/>
+        <location filename="../initializing.cc" line="30"/>
+        <source>Please wait while indexing dictionary</source>
+        <translation>Интизор шавед, луғат татбиқ шуда истодааст</translation>
+    </message>
+    <message>
+        <location filename="../initializing.ui" line="38"/>
+        <source>Dictionary Name</source>
+        <translation>Номи луғат</translation>
+    </message>
+    <message>
+        <location filename="../initializing.cc" line="21"/>
+        <source>Please wait...</source>
+        <translation>Интизор шавед...</translation>
+    </message>
+</context>
+<context>
+    <name>Language</name>
+    <message>
+        <location filename="../language.cc" line="55"/>
+        <source>Afar</source>
+        <translation>Афарӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="56"/>
+        <source>Abkhazian</source>
+        <translation>Абхозӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="57"/>
+        <source>Avestan</source>
+        <translation>Авестоӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="58"/>
+        <source>Afrikaans</source>
+        <translation>Африкаансӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="59"/>
+        <source>Akan</source>
+        <translation>Аконӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="60"/>
+        <source>Amharic</source>
+        <translation>Амхарӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="61"/>
+        <source>Aragonese</source>
+        <translation>Арагонсӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="62"/>
+        <source>Arabic</source>
+        <translation>Арабӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="63"/>
+        <source>Assamese</source>
+        <translation>Ассамесӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="64"/>
+        <source>Avaric</source>
+        <translation>Аварикӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="65"/>
+        <source>Aymara</source>
+        <translation>Аймараӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="66"/>
+        <source>Azerbaijani</source>
+        <translation>Озарбойҷонӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="67"/>
+        <source>Bashkir</source>
+        <translation>Бошқирдӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="68"/>
+        <source>Belarusian</source>
+        <translation>Белорусӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="69"/>
+        <source>Bulgarian</source>
+        <translation>Булғорӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="70"/>
+        <source>Bihari</source>
+        <translation>Бихарӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="71"/>
+        <source>Bislama</source>
+        <translation>Бислама</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="72"/>
+        <source>Bambara</source>
+        <translation>Бамбара</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="73"/>
+        <source>Bengali</source>
+        <translation>Банголӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="74"/>
+        <source>Tibetan</source>
+        <translation>Тибетӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="75"/>
+        <source>Breton</source>
+        <translation>Бретонӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="76"/>
+        <source>Bosnian</source>
+        <translation>Босниягӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="77"/>
+        <source>Catalan</source>
+        <translation>Каталанӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="78"/>
+        <source>Chechen</source>
+        <translation>Чеченӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="79"/>
+        <source>Chamorro</source>
+        <translation>Чаморроӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="80"/>
+        <source>Corsican</source>
+        <translation>Корсикӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="81"/>
+        <source>Cree</source>
+        <translation>Креӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="82"/>
+        <source>Czech</source>
+        <translation>Чехӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="83"/>
+        <source>Church Slavic</source>
+        <translation>Славянии динӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="84"/>
+        <source>Chuvash</source>
+        <translation>Чувашӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="85"/>
+        <source>Welsh</source>
+        <translation>Уэлсӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="86"/>
+        <source>Danish</source>
+        <translation>Даниягӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="87"/>
+        <source>German</source>
+        <translation>Олмонӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="88"/>
+        <source>Divehi</source>
+        <translation>Дивехӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="89"/>
+        <source>Dzongkha</source>
+        <translation>Дзонгкагӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="90"/>
+        <source>Ewe</source>
+        <translation>Ив</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="91"/>
+        <source>Greek</source>
+        <translation>Юнонӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="92"/>
+        <source>English</source>
+        <translation>Англисӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="93"/>
+        <source>Esperanto</source>
+        <translation>Эсперанто</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="94"/>
+        <source>Spanish</source>
+        <translation>Испанӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="95"/>
+        <source>Estonian</source>
+        <translation>Эстонӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="96"/>
+        <source>Basque</source>
+        <translation>Баскӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="97"/>
+        <source>Persian</source>
+        <translation>Форсӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="98"/>
+        <source>Fulah</source>
+        <translation>Фулахӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="99"/>
+        <source>Finnish</source>
+        <translation>Финӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="100"/>
+        <source>Fijian</source>
+        <translation>Фиҷӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="101"/>
+        <source>Faroese</source>
+        <translation>Фароесӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="102"/>
+        <source>French</source>
+        <translation>Франсавӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="103"/>
+        <source>Western Frisian</source>
+        <translation>Фризиани ғарбӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="104"/>
+        <source>Irish</source>
+        <translation>Ирландӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="105"/>
+        <source>Scottish Gaelic</source>
+        <translation>Шотландӣ-галикӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="106"/>
+        <source>Galician</source>
+        <translation>Галисӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="107"/>
+        <source>Guarani</source>
+        <translation>Гуаранӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="108"/>
+        <source>Gujarati</source>
+        <translation>Гуҷаратӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="109"/>
+        <source>Manx</source>
+        <translation>Манксӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="110"/>
+        <source>Hausa</source>
+        <translation>Хаусагӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="111"/>
+        <source>Hebrew</source>
+        <translation>Яҳудӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="112"/>
+        <source>Hindi</source>
+        <translation>Ҳиндӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="113"/>
+        <source>Hiri Motu</source>
+        <translation>Хири моту</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="114"/>
+        <source>Croatian</source>
+        <translation>Хорватӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="115"/>
+        <source>Haitian</source>
+        <translation>Гаитӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="116"/>
+        <source>Hungarian</source>
+        <translation>Венгерӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="117"/>
+        <source>Armenian</source>
+        <translation>Арманӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="118"/>
+        <source>Herero</source>
+        <translation>Хереро</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="119"/>
+        <source>Interlingua</source>
+        <translation>Интерлингва</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="120"/>
+        <source>Indonesian</source>
+        <translation>Индонезӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="121"/>
+        <source>Interlingue</source>
+        <translation>Интерлингуӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="122"/>
+        <source>Igbo</source>
+        <translation>Игбоӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="123"/>
+        <source>Sichuan Yi</source>
+        <translation>Сичуан Юи</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="124"/>
+        <source>Inupiaq</source>
+        <translation>Инупиакӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="125"/>
+        <source>Ido</source>
+        <translation>Идо</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="126"/>
+        <source>Icelandic</source>
+        <translation>Исландӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="127"/>
+        <source>Italian</source>
+        <translation>Итолиёӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="128"/>
+        <source>Inuktitut</source>
+        <translation>Инуктитутӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="129"/>
+        <source>Japanese</source>
+        <translation>Ҷопонӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="130"/>
+        <source>Javanese</source>
+        <translation>Ёвонӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="131"/>
+        <source>Georgian</source>
+        <translation>Гурҷӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="132"/>
+        <source>Kongo</source>
+        <translation>Конго</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="133"/>
+        <source>Kikuyu</source>
+        <translation>Кикуйю</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="134"/>
+        <source>Kwanyama</source>
+        <translation>Кваняма</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="135"/>
+        <source>Kazakh</source>
+        <translation>Қазоқӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="136"/>
+        <source>Kalaallisut</source>
+        <translation>Гренландӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="137"/>
+        <source>Khmer</source>
+        <translation>Хмерӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="138"/>
+        <source>Kannada</source>
+        <translation>Каннадӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="139"/>
+        <source>Korean</source>
+        <translation>Кореягӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="140"/>
+        <source>Kanuri</source>
+        <translation>Канарӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="141"/>
+        <source>Kashmiri</source>
+        <translation>Кашмирӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="142"/>
+        <source>Kurdish</source>
+        <translation>Курдӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="143"/>
+        <source>Komi</source>
+        <translation>Комӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="144"/>
+        <source>Cornish</source>
+        <translation>Корнишӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="145"/>
+        <source>Kirghiz</source>
+        <translation>Қирғизӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="146"/>
+        <source>Latin</source>
+        <translation>Лотинӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="147"/>
+        <source>Luxembourgish</source>
+        <translation>Люксембургӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="148"/>
+        <source>Ganda</source>
+        <translation>Ганд</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="149"/>
+        <source>Limburgish</source>
+        <translation>Лимбургӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="150"/>
+        <source>Lingala</source>
+        <translation>Лингала</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="151"/>
+        <source>Lao</source>
+        <translation>Лао</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="152"/>
+        <source>Lithuanian</source>
+        <translation>Литвонӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="153"/>
+        <source>Luba-Katanga</source>
+        <translation>Луба-Катанга</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="154"/>
+        <source>Latvian</source>
+        <translation>Латишӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="155"/>
+        <source>Malagasy</source>
+        <translation>Малагасӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="156"/>
+        <source>Marshallese</source>
+        <translation>Маршалӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="157"/>
+        <source>Maori</source>
+        <translation>Маорӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="158"/>
+        <source>Macedonian</source>
+        <translation>Мақдунӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="159"/>
+        <source>Malayalam</source>
+        <translation>Малайаламӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="160"/>
+        <source>Mongolian</source>
+        <translation>Муғулӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="161"/>
+        <source>Marathi</source>
+        <translation>Маратхӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="162"/>
+        <source>Malay</source>
+        <translation>Малайӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="163"/>
+        <source>Maltese</source>
+        <translation>Малтӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="164"/>
+        <source>Burmese</source>
+        <translation>Бурмезӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="165"/>
+        <source>Nauru</source>
+        <translation>Науру</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="166"/>
+        <source>Norwegian Bokmal</source>
+        <translation>Норвегӣ-букмалӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="167"/>
+        <source>North Ndebele</source>
+        <translation>Ндебелӣ-шимолӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="168"/>
+        <source>Nepali</source>
+        <translation>Непалӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="169"/>
+        <source>Ndonga</source>
+        <translation>Ндонга</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="170"/>
+        <source>Dutch</source>
+        <translation>Ҳоландӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="171"/>
+        <source>Norwegian Nynorsk</source>
+        <translation>Норвегӣ-нюнорскӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="172"/>
+        <source>Norwegian</source>
+        <translation>Норвегӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="173"/>
+        <source>South Ndebele</source>
+        <translation>Ндебелӣ-ҷанубӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="174"/>
+        <source>Navajo</source>
+        <translation>Наваҷоӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="175"/>
+        <source>Chichewa</source>
+        <translation>Чичевагӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="176"/>
+        <source>Occitan</source>
+        <translation>Окситанӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="177"/>
+        <source>Ojibwa</source>
+        <translation>Оҷибвагӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="178"/>
+        <source>Oromo</source>
+        <translation>Оромоӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="179"/>
+        <source>Oriya</source>
+        <translation>Ориёӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="180"/>
+        <source>Ossetian</source>
+        <translation>Осетинӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="181"/>
+        <source>Panjabi</source>
+        <translation>Панҷабӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="182"/>
+        <source>Pali</source>
+        <translation>Палӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="183"/>
+        <source>Polish</source>
+        <translation>Полякӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="184"/>
+        <source>Pashto</source>
+        <translation>Паштӯ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="185"/>
+        <source>Portuguese</source>
+        <translation>Португалӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="186"/>
+        <source>Quechua</source>
+        <translation>Кечуа</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="187"/>
+        <source>Raeto-Romance</source>
+        <translation>Рито-романӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="188"/>
+        <source>Kirundi</source>
+        <translation>Кирундӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="189"/>
+        <source>Romanian</source>
+        <translation>Руминӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="190"/>
+        <source>Russian</source>
+        <translation>Русӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="191"/>
+        <source>Kinyarwanda</source>
+        <translation>Киняруанда</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="192"/>
+        <source>Sanskrit</source>
+        <translation>Санскрит</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="193"/>
+        <source>Sardinian</source>
+        <translation>Сардинӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="194"/>
+        <source>Sindhi</source>
+        <translation>Синдхӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="195"/>
+        <source>Northern Sami</source>
+        <translation>Самии-шимолӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="196"/>
+        <source>Sango</source>
+        <translation>Сангоӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="197"/>
+        <source>Serbo-Croatian</source>
+        <translation>Сербӣ-хорватӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="198"/>
+        <source>Sinhala</source>
+        <translation>Синхала</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="199"/>
+        <source>Slovak</source>
+        <translation>Словакӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="200"/>
+        <source>Slovenian</source>
+        <translation>Словенӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="201"/>
+        <source>Samoan</source>
+        <translation>Самоанӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="202"/>
+        <source>Shona</source>
+        <translation>Шонагӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="203"/>
+        <source>Somali</source>
+        <translation>Сомалӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="204"/>
+        <source>Albanian</source>
+        <translation>Албанӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="205"/>
+        <source>Serbian</source>
+        <translation>Сербӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="206"/>
+        <source>Swati</source>
+        <translation>Сватӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="207"/>
+        <source>Southern Sotho</source>
+        <translation>Сотои ҷанубӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="208"/>
+        <source>Sundanese</source>
+        <translation>Сунданезӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="209"/>
+        <source>Swedish</source>
+        <translation>Шведӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="210"/>
+        <source>Swahili</source>
+        <translation>Свахилӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="211"/>
+        <source>Tamil</source>
+        <translation>Тамилӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="212"/>
+        <source>Telugu</source>
+        <translation>Телугӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="213"/>
+        <source>Tajik</source>
+        <translation>Тоҷикӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="214"/>
+        <source>Thai</source>
+        <translation>Тайӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="215"/>
+        <source>Tigrinya</source>
+        <translation>Тигринӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="216"/>
+        <source>Turkmen</source>
+        <translation>Туркманӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="217"/>
+        <source>Tagalog</source>
+        <translation>Тагалогӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="218"/>
+        <source>Tswana</source>
+        <translation>Тсвана</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="219"/>
+        <source>Tonga</source>
+        <translation>Тонга</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="220"/>
+        <source>Turkish</source>
+        <translation>Туркӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="221"/>
+        <source>Tsonga</source>
+        <translation>Тсонга</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="222"/>
+        <source>Tatar</source>
+        <translation>Тоторӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="223"/>
+        <source>Twi</source>
+        <translation>Тви</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="224"/>
+        <source>Tahitian</source>
+        <translation>Таитӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="225"/>
+        <source>Uighur</source>
+        <translation>Уйғурӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="226"/>
+        <source>Ukrainian</source>
+        <translation>Украинӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="227"/>
+        <source>Urdu</source>
+        <translation>Урдӯ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="228"/>
+        <source>Uzbek</source>
+        <translation>Ӯзбекӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="229"/>
+        <source>Venda</source>
+        <translation>Венда</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="230"/>
+        <source>Vietnamese</source>
+        <translation>Ветнамӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="231"/>
+        <source>Volapuk</source>
+        <translation>Волапук</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="232"/>
+        <source>Walloon</source>
+        <translation>Валлонӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="233"/>
+        <source>Wolof</source>
+        <translation>Волофӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="234"/>
+        <source>Xhosa</source>
+        <translation>Кхоса</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="235"/>
+        <source>Yiddish</source>
+        <translation>Ибрӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="236"/>
+        <source>Yoruba</source>
+        <translation>Йорубӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="237"/>
+        <source>Zhuang</source>
+        <translation>Чжуанӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="238"/>
+        <source>Chinese</source>
+        <translation>Хитоӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="239"/>
+        <source>Zulu</source>
+        <translation>Зулӯ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="374"/>
+        <source>Traditional Chinese</source>
+        <translation>Хитои анъанавӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="375"/>
+        <source>Simplified Chinese</source>
+        <translation>Хитои оддӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="376"/>
+        <source>Other</source>
+        <translation>Дигар</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="377"/>
+        <source>Other Simplified Chinese dialects</source>
+        <translation>Лаҳҷаҳои хитои оддии дигар</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="378"/>
+        <source>Other Traditional Chinese dialects</source>
+        <translation>Лаҳҷаҳои хитои анъанавии дигар</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="379"/>
+        <source>Other Eastern-European languages</source>
+        <translation>Забонҳои аврупои шарқии дигар</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="380"/>
+        <source>Other Western-European languages</source>
+        <translation>Забонҳои аврупои ғарбии дигар</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="381"/>
+        <source>Other Russian languages</source>
+        <translation>Дигар забонҳои русӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="382"/>
+        <source>Other Japanese languages</source>
+        <translation>Дигар забонҳои ҷопонӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="383"/>
+        <source>Other Baltic languages</source>
+        <translation>Дигар забонҳои балтикӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="384"/>
+        <source>Other Greek languages</source>
+        <translation>Дигар забонҳои юнонӣ</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="385"/>
+        <source>Other Korean dialects</source>
+        <translation>Лаҳҷаҳои кореягии дигар</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="386"/>
+        <source>Other Turkish dialects</source>
+        <translation>Лаҳҷаҳои туркии дигар</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="387"/>
+        <source>Other Thai dialects</source>
+        <translation>Лаҳҷаҳои тайии дигар</translation>
+    </message>
+    <message>
+        <location filename="../language.cc" line="388"/>
+        <source>Tamazight</source>
+        <translation>Тамазайд</translation>
+    </message>
+</context>
+<context>
+    <name>LoadDictionaries</name>
+    <message>
+        <location filename="../loaddictionaries.cc" line="204"/>
+        <source>Error loading dictionaries</source>
+        <translation>Ҳангоми боркунии луғатҳо хато ба вуҷуд омад</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../mainwindow.ui" line="14"/>
+        <location filename="../mainwindow.cc" line="1123"/>
+        <location filename="../mainwindow.cc" line="2000"/>
+        <source>GoldenDict</source>
+        <translation>Луғати GoldenDict</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="46"/>
+        <location filename="../mainwindow.cc" line="460"/>
+        <source>Welcome!</source>
+        <translation>Хуш омадед!</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="69"/>
+        <source>&amp;File</source>
+        <translation>&amp;Файл</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="86"/>
+        <source>&amp;Edit</source>
+        <translation>&amp;Танзимот</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="93"/>
+        <source>&amp;Help</source>
+        <translation>&amp;Роҳнамо</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="104"/>
+        <source>&amp;View</source>
+        <translation>&amp;Намоиш</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="108"/>
+        <source>&amp;Zoom</source>
+        <translation>&amp;Андозаи ҳарфҳоро иваз кунед</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="115"/>
+        <source>H&amp;istory</source>
+        <translation>&amp;Таърих</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="130"/>
+        <source>Search Pane</source>
+        <translation>Лавҳаи ҷустуҷӯ</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="257"/>
+        <source>Results Navigation Pane</source>
+        <translation>Лавҳаи натиҷаҳои ҷустуҷӯ</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="288"/>
+        <source>&amp;Dictionaries...	F3</source>
+        <translation>&amp;Луғатҳо...	F3</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="297"/>
+        <source>&amp;Preferences...</source>
+        <translation>&amp;Хусусиятҳо...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="300"/>
+        <source>F4</source>
+        <translation>F4</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="305"/>
+        <source>&amp;Homepage</source>
+        <translation>&amp;Вебсайти луғат</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="310"/>
+        <source>&amp;About</source>
+        <translation>&amp;Дар бораи барнома</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="313"/>
+        <source>About GoldenDict</source>
+        <translation>Дар бораи GoldenDict</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="316"/>
+        <source>F1</source>
+        <translation>F1</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="321"/>
+        <location filename="../mainwindow.cc" line="165"/>
+        <source>&amp;Quit</source>
+        <translation>&amp;Хомӯш кунед</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="324"/>
+        <source>Quit from application</source>
+        <translation>Аз барнома хомӯш кунед</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="327"/>
+        <source>Ctrl+Q</source>
+        <translation>Ctrl+Q</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="332"/>
+        <source>&amp;Forum</source>
+        <translation>&amp;Форуми луғат</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="337"/>
+        <source>&amp;Close To Tray</source>
+        <translation>&amp;Ба панел печонед</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="340"/>
+        <source>Minimizes the window to tray</source>
+        <translation>Тирезаро ба панел печонад</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="343"/>
+        <source>Ctrl+F4</source>
+        <translation>Ctrl+F4</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="352"/>
+        <source>&amp;Save Article</source>
+        <translation>&amp;Мақоларо захира кунед</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="355"/>
+        <source>Save Article</source>
+        <translation>Мақоларо захира кунед</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="358"/>
+        <source>F2</source>
+        <translation>F2</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="367"/>
+        <source>&amp;Print</source>
+        <translation>&amp;Чоп кунед</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="370"/>
+        <source>Ctrl+P</source>
+        <translation>Ctrl+P</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="375"/>
+        <source>Page Set&amp;up</source>
+        <translation>&amp;Танзими саҳифа</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="380"/>
+        <source>Print Preview</source>
+        <translation>Пешнамоиши чоп</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="385"/>
+        <source>Rescan Files</source>
+        <translation>Файлҳоро аз нав коркард кунед</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="388"/>
+        <source>Ctrl+F5</source>
+        <translation>Ctrl+F5</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="393"/>
+        <source>&amp;Clear</source>
+        <translation>&amp;Пок кунед</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="402"/>
+        <location filename="../mainwindow.cc" line="348"/>
+        <source>New Tab</source>
+        <translation>Варақаи нав</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="405"/>
+        <source>Ctrl+T</source>
+        <translation>Ctrl+T</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="413"/>
+        <source>&amp;Configuration Folder</source>
+        <translation>&amp;Ҷузвдони танзимот</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="418"/>
+        <location filename="../mainwindow.cc" line="2630"/>
+        <source>&amp;Show</source>
+        <translation>&amp;Намоиш диҳед</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="423"/>
+        <source>&amp;Export</source>
+        <translation>&amp;Захира кунед</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="45"/>
+        <source>Show Names in Dictionary Bar</source>
+        <translation>Номҳоро дар лавҳаи луғат нишон диҳед</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="46"/>
+        <source>Show Small Icons in Toolbars</source>
+        <translation>Нишонаҳои хурдро дар лавҳаи асбобҳо нишон диҳед</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="47"/>
+        <source>&amp;Menubar</source>
+        <translation>&amp;Лавҳаи меню</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="75"/>
+        <location filename="../mainwindow.cc" line="747"/>
+        <source>Look up in:</source>
+        <translation>Тарҷума дар:</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="88"/>
+        <source>Found in Dictionaries:</source>
+        <translation>Дар луғатҳои зерин дарёфт шуд:</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="97"/>
+        <source>Navigation</source>
+        <translation>Лавҳаи идоракунӣ</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="100"/>
+        <source>Back</source>
+        <translation>Ақиб</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="101"/>
+        <source>Forward</source>
+        <translation>Пеш</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="110"/>
+        <source>Scan Popup</source>
+        <translation>Тарҷумаи пайдошаванда</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="120"/>
+        <source>Pronounce Word (Alt+S)</source>
+        <translation>Калимаро талаффуз кунед (Alt+S)</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="129"/>
+        <source>Zoom In</source>
+        <translation>Бузург кунед</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="131"/>
+        <source>Zoom Out</source>
+        <translation>Хурд кунед</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="133"/>
+        <source>Normal Size</source>
+        <translation>Андозаи муқаррарӣ</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="149"/>
+        <source>Words Zoom In</source>
+        <translation>Калимаҳоро бузург кунед</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="151"/>
+        <source>Words Zoom Out</source>
+        <translation>Калимаҳоро хурд кунед</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="153"/>
+        <source>Words Normal Size</source>
+        <translation>Андозаи муқаррарӣ</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="161"/>
+        <source>Show &amp;Main Window</source>
+        <translation>&amp;Тирезаи асосиро намоиш диҳед</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="209"/>
+        <source>Opened tabs</source>
+        <translation>Варақаҳои кушодашуда</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="220"/>
+        <source>Close current tab</source>
+        <translation>Варақаи ҷориро пӯшед</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="230"/>
+        <source>Close all tabs</source>
+        <translation>Ҳамаи варақаҳоро пӯшед</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="238"/>
+        <source>Close all tabs except current</source>
+        <translation>Ҳамаи варақаҳоро ғайр аз ҷорӣ пӯшед</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="338"/>
+        <source>Loading...</source>
+        <translation>Бор шуда истодааст...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="736"/>
+        <source>%1 dictionaries, %2 articles, %3 words</source>
+        <translation>%1 луғат, %2 мақола, %3 калима</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="747"/>
+        <source>Look up:</source>
+        <translation>Тарҷума кунед:</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="765"/>
+        <source>All</source>
+        <translation>Умумӣ</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="876"/>
+        <source>Open Tabs List</source>
+        <translation>Рӯйхати варақаҳоро кушоед</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="934"/>
+        <source>(untitled)</source>
+        <translation>(беном)</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="1123"/>
+        <source>%1 - %2</source>
+        <translation>%1 - %2</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="1562"/>
+        <source>WARNING: %1</source>
+        <translation>ОГОҲӢ: %1</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="2001"/>
+        <source>Failed to initialize hotkeys monitoring mechanism.&lt;br&gt;Make sure your XServer has RECORD extension turned on.</source>
+        <translation>Омодасозии механизми назорати тугмаҳои зеркор қатъ карда шуд.&lt;br&gt;Мутмаин шавед, ки имконоти RECORD дар XServer фаъол аст.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="2135"/>
+        <source>New Release Available</source>
+        <translation>Версияи барномаи нав дастрас аст</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="2136"/>
+        <source>Version &lt;b&gt;%1&lt;/b&gt; of GoldenDict is now available for download.&lt;br&gt;Click &lt;b&gt;Download&lt;/b&gt; to get to the download page.</source>
+        <translation>Версияи навтарини луғати GoldenDict &lt;b&gt;%1&lt;/b&gt; барои боргирӣ дастрас аст.&lt;br&gt;Барои кушодани саҳифаи боргирии барнома, тугмаи &lt;b&gt;Боргириро&lt;/b&gt; зер кунед.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="2141"/>
+        <source>Download</source>
+        <translation>Боргирӣ кунед</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="2142"/>
+        <source>Skip This Release</source>
+        <translation>Ин версияро гузаред</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="2255"/>
+        <source>You have chosen to hide a menubar. Use %1 to show it back.</source>
+        <translation>Шумо пинҳон кардани лавҳаи менюро интихоб кардед. Барои аз нав намоиш додани лавҳаи меню, %1-ро истифода баред.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="2256"/>
+        <source>Ctrl+M</source>
+        <translation>Ctrl+M</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="2404"/>
+        <source>Page Setup</source>
+        <translation>Танзими саҳифа</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="2405"/>
+        <source>No printer is available. Please install one first.</source>
+        <translation>Ягон принтер дастрас нест. Пеш аз ҳамам шумо бояд принтерро танзим кунед.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="2422"/>
+        <source>Print Article</source>
+        <translation>Мақоларо чоп кунед</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="2443"/>
+        <source>Save Article As</source>
+        <translation>Мақоларо ҳамчун ... захира кунед</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="2443"/>
+        <source>Html files (*.html *.htm)</source>
+        <translation>Файлҳои html (*.html *.htm)</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="2458"/>
+        <source>Error</source>
+        <translation>Хато</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="2459"/>
+        <source>Can&apos;t save article: %1</source>
+        <translation>Мақола захира нашуд: %1</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="2660"/>
+        <source>&amp;Hide</source>
+        <translation>&amp;Пинҳон кунед</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="2664"/>
+        <source>History view mode</source>
+        <translation>Ҳолати намоиши таърих</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="2689"/>
+        <source>Export history to file</source>
+        <translation>Таърихро дар файл захира кунед</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="2691"/>
+        <source>Text files (*.txt);;All files (*.*)</source>
+        <translation>Файлҳои матнӣ (*.txt);;Ҳамаи файлҳо (*.*)</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="2729"/>
+        <source>History export complete</source>
+        <translation>Захиракунии таърих ба анҷом расид</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cc" line="2732"/>
+        <source>Export error: </source>
+        <translation>Хатои захиракунӣ: </translation>
+    </message>
+</context>
+<context>
+    <name>MediaWiki::MediaWikiArticleRequest</name>
+    <message>
+        <location filename="../mediawiki.cc" line="276"/>
+        <source>XML parse error: %1 at %2,%3</source>
+        <translation>Хатои таҳлили XML: %1 дар %2,%3</translation>
+    </message>
+</context>
+<context>
+    <name>MediaWiki::MediaWikiWordSearchRequest</name>
+    <message>
+        <location filename="../mediawiki.cc" line="151"/>
+        <source>XML parse error: %1 at %2,%3</source>
+        <translation>Хатои таҳлили XML: %1 дар %2,%3</translation>
+    </message>
+</context>
+<context>
+    <name>MediaWikisModel</name>
+    <message>
+        <location filename="../sources.cc" line="390"/>
+        <source>Enabled</source>
+        <translation>Фаъолшуда</translation>
+    </message>
+    <message>
+        <location filename="../sources.cc" line="392"/>
+        <source>Name</source>
+        <translation>Ном</translation>
+    </message>
+    <message>
+        <location filename="../sources.cc" line="394"/>
+        <source>Address</source>
+        <translation>Суроға</translation>
+    </message>
+</context>
+<context>
+    <name>OrderAndProps</name>
+    <message>
+        <location filename="../orderandprops.ui" line="14"/>
+        <source>Form</source>
+        <translation>Шакл</translation>
+    </message>
+    <message>
+        <location filename="../orderandprops.ui" line="26"/>
+        <source>Dictionary order:</source>
+        <translation>Тартиби луғатҳо:</translation>
+    </message>
+    <message>
+        <location filename="../orderandprops.ui" line="51"/>
+        <location filename="../orderandprops.ui" line="61"/>
+        <location filename="../orderandprops.ui" line="101"/>
+        <location filename="../orderandprops.ui" line="111"/>
+        <source>...</source>
+        <translation>...</translation>
+    </message>
+    <message>
+        <location filename="../orderandprops.ui" line="136"/>
+        <source>Inactive (disabled) dictionaries:</source>
+        <translation>Луғатҳои ғайрифаъол (хомӯшшуда):</translation>
+    </message>
+    <message>
+        <location filename="../orderandprops.ui" line="150"/>
+        <source>Dictionary information</source>
+        <translation>Маълумоти луғат</translation>
+    </message>
+    <message>
+        <location filename="../orderandprops.ui" line="158"/>
+        <source>Name:</source>
+        <translation>Ном:</translation>
+    </message>
+    <message>
+        <location filename="../orderandprops.ui" line="185"/>
+        <source>Total articles:</source>
+        <translation>Мақолаҳои ҳамагӣ:</translation>
+    </message>
+    <message>
+        <location filename="../orderandprops.ui" line="192"/>
+        <source>Total words:</source>
+        <translation>Калимаҳои ҳамагӣ:</translation>
+    </message>
+    <message>
+        <location filename="../orderandprops.ui" line="209"/>
+        <source>Translates from:</source>
+        <translation>Тарҷумашуда аз:</translation>
+    </message>
+    <message>
+        <location filename="../orderandprops.ui" line="216"/>
+        <source>Translates to:</source>
+        <translation>Тарҷумашуда ба:</translation>
+    </message>
+    <message>
+        <location filename="../orderandprops.ui" line="271"/>
+        <source>Files comprising this dictionary:</source>
+        <translation>Файлҳои луғат:</translation>
+    </message>
+    <message>
+        <location filename="../orderandprops.ui" line="336"/>
+        <source>Adjust the order by dragging and dropping items in it. Drop dictionaries to the inactive group to disable their use.</source>
+        <translatorcomment> Ба воситаи ҷойивазкунии чизҳо тартибро танзим кунед. Барои хомӯш кардани луғатҳо, онҳоро ба гурӯҳи ғайрифаъол ҷойиваз кунед.</translatorcomment>
+        <translation> Adjust the order by dragging and dropping items in it. Drop dictionaries to the inactive group to disable their use.</translation>
+    </message>
+</context>
+<context>
+    <name>PathsModel</name>
+    <message>
+        <location filename="../sources.cc" line="864"/>
+        <source>Path</source>
+        <translation>Роҳ</translation>
+    </message>
+    <message>
+        <location filename="../sources.cc" line="866"/>
+        <source>Recursive</source>
+        <translation>Бозгаштӣ</translation>
+    </message>
+</context>
+<context>
+    <name>Preferences</name>
+    <message>
+        <location filename="../preferences.ui" line="14"/>
+        <source>Preferences</source>
+        <translation>Хусусиятҳо</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="41"/>
+        <source>&amp;Interface</source>
+        <translation>&amp;Интерфейс</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="60"/>
+        <source>Tabbed browsing</source>
+        <translation>Варақаҳои тарҷума</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="66"/>
+        <source>Normally, opening a new tab switches to it immediately.
+With this on however, new tabs will be opened without
+switching to them.</source>
+        <translation>Одатан, ҳангоми кушодани варақаи нав шумо онро ба воситаи табдилдиҳӣ
+дарҳол дидан мекунед. Аммо, фаъол кардани ин мконот варақаҳои
+навро бе табдилдиҳӣ кушода мекунад.</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="71"/>
+        <source>Open new tabs in background</source>
+        <translation>Варақаҳои навро дар тирезаи асосӣ кушоед</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="78"/>
+        <source>With this on, new tabs are opened just after the
+current, active one. Otherwise they are added to
+be the last ones.</source>
+        <translation>Фаъол кардани ин мконот варақаҳои навро пас аз варақаи
+кушодашуда кушода мекунад. Агар ин имконотро фаъол намекунед
+варақаҳои нав дар охири рӯйхат кушода мешаванд.</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="83"/>
+        <source>Open new tabs after the current one</source>
+        <translation>Варақаҳои навро пас аз варақаи кушодашуда кушоед</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="90"/>
+        <source>Select this option if you don&apos;t want to see the main tab bar when only a single tab is opened.</source>
+        <translation>Имконоти зеринро интихоб кунед, агар варақаи ягона кушода аст ва шумо намехоҳед лавҳаи варақаҳоро дидан кунед.</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="93"/>
+        <source>Hide single tab</source>
+        <translation>Варақаи ягонаро пинҳон кунед</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="100"/>
+        <source>Ctrl-Tab navigates tabs in MRU order</source>
+        <translation>Тугмабандии Ctrl-Tab варақаҳоро дар тартиби MRU табдил мекунад</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="110"/>
+        <source>When enabled, an icon appears in the sytem tray area which can be used
+to open main window and perform other tasks.</source>
+        <translation>Агар имконоти зерин фаъол бошад, нишонаи луғат дар панели система пайдо мешавад,
+ва шумо аз он ҷо метавонед тирезаи асосии барномаро кушоед ва амалҳои дигарро иҷро кунед.</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="114"/>
+        <source>Enable system tray icon</source>
+        <translation>Нишонаи луғатро дар панел фаъол кунед</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="132"/>
+        <source>With this on, the application starts directly to system tray without showing
+its main window.</source>
+        <translation>Агар имконоти зерин фаъол бошад, ҳангоми кушоиши луғат танҳо нишонааш дар панели система
+пайдо мешавад ва тирезаи асосиаш нишон дода намешавад.</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="136"/>
+        <source>Start to system tray</source>
+        <translation>Танҳо нишонаи луғатро дар панели система нишон диҳед</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="143"/>
+        <source>With this on, an attempt to close main window would hide it instead of closing
+the application.</source>
+        <translation>Агар имконоти зерин фаъол бошад, кӯшиши хомушкунӣ барномаро танҳо
+пинҳон мекунад.</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="147"/>
+        <source>Close to system tray</source>
+        <translation>Луғатро ба панели система пинҳон кунед</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="157"/>
+        <source>Startup</source>
+        <translation>Оғози кор</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="163"/>
+        <source>Automatically starts GoldenDict after operation system bootup.</source>
+        <translation>Луғати GoldenDict-ро ҳангоми боркунии системаи оператсионӣ ба худкор оғоз мекунад.</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="166"/>
+        <source>Start with system</source>
+        <translation>Луғатро бо системаи оператсионӣ оғоз кунед</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="178"/>
+        <source>Interface language:</source>
+        <translation>Забони интерфейс:</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="204"/>
+        <source>Display style:</source>
+        <translation>Мавзӯъи луғат:</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="258"/>
+        <source>Double-click translates the word clicked</source>
+        <translation>Пахши дубора калимаи пахшшударо тарҷума мекунад</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="265"/>
+        <source>Normally, pressing ESC key moves focus to the translation line.
+With this on however, it will hide the main window.</source>
+        <translation>Одатан, бо зеркунии тугмаи ESC нишондиҳандаи муш ба сатри тарҷума гузаронида мешавад.
+Вале бо фаъолкунии ин имконот, тирезаи асосӣ пинҳон карда мешавад.</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="269"/>
+        <source>ESC key hides main window</source>
+        <translation>Тугмаи ESC тирезаи асосиро пинҳон мекунад</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="281"/>
+        <source>&amp;Scan Popup</source>
+        <translation>&amp;Тарҷумаи пайдошаванда</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="300"/>
+        <source>When enabled, a translation popup window would be shown each time
+you point your mouse on any word on the screen (Windows) or select
+any word with mouse (Linux). When enabled, you can switch it on and
+off from main window or tray icon.</source>
+        <translation>Агар имконоти зерин фаъол бошад, ҳангоми нишондиҳии ягон калима (дар Windows)
+ё интихоб кардани ягон калима (дар Linux) бо муш тирезаи пайдошаванда бо тарҷумаи
+он калима намоиш дода мешавад. Агар фаъол бошад, шумо метавонед инро аз тирезаи асосӣ
+ё панели система хомӯш кунед ё аз нав фаъол созед.</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="306"/>
+        <source>Enable scan popup functionality</source>
+        <translation>Хусусияти тарҷумаи пайдошавандаро фаъол кунед</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="318"/>
+        <source>Chooses whether the scan popup mode is on by default or not. If checked,
+the program would always start with the scan popup active.</source>
+        <translation>Барои фаъол ё хомӯш кардани тарҷумаи пайдошаванда, имконоти зеринро истифода баред.
+Агар ин имконотро интихоб мекунед, тарҷумаи пайдошаванда ба худкор фаъол мешавад.</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="322"/>
+        <source>Start with scan popup turned on</source>
+        <translation>Бо хусусияти тарҷумаи пайдошаванда барномаро оғоз кунед</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="329"/>
+        <source>With this enabled, the popup would only show up if all chosen keys are
+in the pressed state when the word selection changes.</source>
+        <translation>Бо имконоти фаъолшудаи зерин, тарҷумаи пайдошаванда намоиш дода мешавад,
+агар ҳангоми интихоби калима ҳамаи тугмаҳои интихобшуда зер шуда истодаанд.</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="333"/>
+        <source>Only show popup when all selected keys are kept pressed:</source>
+        <translation>Тарҷумаи пайдошавандаро намоиш диҳед, агар ҳамаи тугмаҳои интихобшуда зер шуда истодаанд:</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="372"/>
+        <source>Left Ctrl only</source>
+        <translation>Танҳо Ctrl-и чап</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="375"/>
+        <source>Left Ctrl</source>
+        <translation>Ctrl-и чап</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="382"/>
+        <source>Right Shift only</source>
+        <translation>Танҳо Shift-и рост</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="385"/>
+        <source>Right Shift</source>
+        <translation>Shift-и рост</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="392"/>
+        <source>Alt key</source>
+        <translation>Тугмаи Alt</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="395"/>
+        <source>Alt</source>
+        <translation>Alt</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="402"/>
+        <source>Ctrl key</source>
+        <translation>Тугмаи Ctrl</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="405"/>
+        <source>Ctrl</source>
+        <translation>Ctrl</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="412"/>
+        <source>Left Alt only</source>
+        <translation>Танҳо Alt-и чап</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="415"/>
+        <source>Left Alt</source>
+        <translation>Alt-и чап</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="422"/>
+        <source>Shift key</source>
+        <translation>Тугмаи Shift</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="425"/>
+        <source>Shift</source>
+        <translation>Shift</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="432"/>
+        <source>Right Alt only</source>
+        <translation>Танҳо Alt-и рост</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="435"/>
+        <source>Right Alt</source>
+        <translation>Alt-и рост</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="442"/>
+        <source>Right Ctrl only</source>
+        <translation>Танҳо Ctrl-и рост</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="445"/>
+        <source>Right Ctrl</source>
+        <translation>Ctrl-и рост</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="452"/>
+        <source>Left Shift only</source>
+        <translation>Танҳо Shift-и чап</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="455"/>
+        <source>Left Shift</source>
+        <translation>Shift-и чап</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="462"/>
+        <source>Windows key or Meta key</source>
+        <translation>Тугмаи Windows ё Meta</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="465"/>
+        <source>Win/Meta</source>
+        <translation>Win/Meta</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="499"/>
+        <source>Normally, in order to activate a popup you have to
+maintain the chosen keys pressed while you select
+a word. With this enabled, the chosen keys may also
+be pressed shortly after the selection is done.</source>
+        <translation>Одатан, барои фаъол кардани тарҷумаи пайдошаванда шумо
+бояд тугмаҳои интихобшударо дар баробари интихобкунии калима
+зер кунед. Агар шумо имконоти зеринро интихоб мекунед, метавонед
+тугмаҳои интихобшударо баъд аз интихобкунии калима зер кунед.</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="505"/>
+        <source>Keys may also be pressed afterwards, within</source>
+        <translation>Зеркунии тугмаҳои интихобшуда баъд аз</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="512"/>
+        <source>To avoid false positives, the keys are only monitored
+after the selection&apos;s done for a limited amount of
+seconds, which is specified here.</source>
+        <translatorcomment>Чтобы избавитӣся  ложных срабатываний, после выделения слова
+клавиши опрашиваются только в течение ограниченного
+промежутка времени, который и задается здесь.</translatorcomment>
+        <translation>Барои намоиш додани тарҷумаи пайдошаванда баъд аз
+интихобкунии калима, шумо бояд тугмаҳои интихобшударо дар
+муддати сонияҳои таъйиншуда зер кунед. Агар тугмаҳоро баъд
+аз муддати таъйиншуда  зер мекунед, тарҷума пайдо намешавад.</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="536"/>
+        <source>secs</source>
+        <translation>сония</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="558"/>
+        <source>Send translated word to main window instead of to show it in popup window</source>
+        <translation>Калимаи тарҷумашударо ба ҷои тирезаи пайдошаванда дар тирезаи асосӣ нишон диҳед</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="561"/>
+        <source>Send translated word to main window</source>
+        <translation>Калимаи тарҷумашударо дар тирезаи асосӣ нишон диҳед</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="589"/>
+        <source>Hotkeys</source>
+        <translation>Тугмаҳои тезкор</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="608"/>
+        <source>Use the following hotkey to show or hide the main window:</source>
+        <translation>Барои пинҳон ва намоиш додани тирезаи асосӣ тугмаҳои зеринро истифода баред:</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="639"/>
+        <source>Use the following hotkey to translate a word from clipboard:</source>
+        <translation>Барои таҷума кардани калимаҳо аз ҳофизаи система тугмаҳои зеринро истифода баред:</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="686"/>
+        <source>The hotkeys are global and work from any program and within any context as long as GoldenDict is running in background.</source>
+        <translation>Тугмаҳои интихобшудаи тезкор ҳамаҷониба мебошанд, вале танҳо ҳангоми фаъол будани луғати GoldenDict бо ягон барнома ё матн кор мекунанд.</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="696"/>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;Note: You appear to be running an X.Org XServer release which has the RECORD extension broken. Hotkeys in GoldenDict will probably not work. This must be fixed in the server itself. Please refer to the following &lt;/span&gt;&lt;a href=&quot;https://bugs.freedesktop.org/show_bug.cgi?id=20500&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;bug entry&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt; and leave a comment there if you like.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;Дар хотир доред, ки: Шумо версияи барномаи X.Org XServer-ро истифода мебаред, ки дорои RECORD-и вайроншуда мебошад. Эҳтимол, тугмаҳои тезкор дар GoldenDict кор намекунанд. Ин мушкилӣ бояд дар худи сервер ҳал карда шавад. Гузоришро барои &lt;/span&gt;&lt;a href=&quot;https://bugs.freedesktop.org/show_bug.cgi?id=20500&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;ворид кардани маълумоти хато дар ин ҷо&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt; пайдо кунед ва агар хоҳиш доред маслиҳати худро дар он ҷо пешниҳод кунед.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="734"/>
+        <source>&amp;Audio</source>
+        <translation>&amp;Аудио</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="753"/>
+        <source>Pronunciation</source>
+        <translation>Талаффуз</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="759"/>
+        <source>Auto-pronounce words in main window</source>
+        <translation>Талаффузи худкори калимаҳо дар тирезаи асосӣ</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="766"/>
+        <source>Auto-pronounce words in scan popup</source>
+        <translation>Талаффузи худкори калимаҳо дар тарҷумаи пайдошаванда</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="776"/>
+        <source>Playback</source>
+        <translation>Иҷрои аудио</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="782"/>
+        <source>Use Windows native playback API. Limited to .wav files only,
+but works very well.</source>
+        <translation>Windows API-ро барои иҷрои аудио истифода баред. Танҳо файлҳои .wav иҷро мешаванд,
+вале сифати ин имконот хеле баланд аст.</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="786"/>
+        <source>Play via Windows native API</source>
+        <translation>Ба воситаи Windows API иҷро кунед</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="793"/>
+        <source>Play audio via Phonon framework. May be somewhat unstable,
+but should support most audio file formats.</source>
+        <translation>Файлҳои аудиоиро ба воситаи барномаи Phonon иҷро кунед. Ин имконот бисёр файлҳои
+аудиоиро дастгирӣ мекунад, вале баъзе файлҳо иҷро карда намешаванд.</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="797"/>
+        <source>Play via Phonon</source>
+        <translation>Ба воситаи Phonon иҷро кунед</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="809"/>
+        <source>Use any external program to play audio files</source>
+        <translation>Ягон барномаи беруниро барои иҷрои файлҳои аудиоӣ истифода баред</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="812"/>
+        <source>Use external program:</source>
+        <translation>Ба воситаи барномаи дигар иҷро кунед:</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="849"/>
+        <source>&amp;Network</source>
+        <translation>&amp;Шабака</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="868"/>
+        <source>Enable if you wish to use a proxy server
+for all program&apos;s network requests.</source>
+        <translation>Агар шумо мехоҳед сервери proxy-ро барои ҳамаи дархостҳои
+шабака истифода баред шумо бояд ин имконотиро фаъол кунед.</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="872"/>
+        <source>Use proxy server</source>
+        <translation>Сервери proxy-ро истифода баред</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="886"/>
+        <source>Type:</source>
+        <translation>Намуд:</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="896"/>
+        <source>Host:</source>
+        <translation>Мизбон:</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="906"/>
+        <source>Port:</source>
+        <translation>Порт:</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="927"/>
+        <source>User:</source>
+        <translation>Корбар:</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="937"/>
+        <source>Password:</source>
+        <translation>Парол:</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="972"/>
+        <source>Enabling this would make GoldenDict block most advertisements
+by disallowing content (images, frames) not originating from the site
+you are browsing. If some site breaks because of this, try disabling this.</source>
+        <translation>Агар шумо имконоти зеринро фаъол мекунед, луғати GoldenDict намоиши рекламаи
+тиҷорие (тасвирҳо, эълонҳо), ки ба вебсайти кушодашуда таалуқ надорад,
+қатъ мекунад. Агар бо сабаби фаъолкунии ин имконот кушодани вебсайт
+имконпазир нест, кӯшиш кунед, ки ин имконотро ғайрифаъол созед.</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="977"/>
+        <source>Disallow loading content from other sites (hides most advertisements)</source>
+        <translation>Намоиши мӯҳтавои тиҷориро аз вебсайтҳои дигар қатъ кунед (рекламаро пинҳон мекунад)</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="984"/>
+        <source>Enabling this would allow to listen to sound pronunciations from
+online dictionaries that rely on Flash or other web plugins.
+Plugin must be installed for this option to work.</source>
+        <translation>Агар шумо инро фаъол мекунед, ба шумо имкон пайдо мешавад, ки тавонед
+талаффузи калимаҳоро аз луғатҳои онлайн дорои Flash ё дигар плагинҳои веб
+гӯш кунед. Барои ин имконот шумо бояд плагини мувофиқро сабт кунед.</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="989"/>
+        <source>Enable web plugins</source>
+        <translation>Плагини вебро фаъол кунед</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="1012"/>
+        <source>When this is enabled, the program periodically
+checks if a new, updated version of GoldenDict
+is available for download. If it is so, the program
+informs the user about it and prompts to open a
+download page.</source>
+        <translation>Агар шумо инро фаъол мекунед, барномаи шумо мавҷуд будани версияи
+навтарини луғати GoldenDict-ро барои боргирӣ такроран тафтиш мекунад.
+Вақте, ки версияи навтарин барои боргирӣ дастрас мешавад, имконоти зерин
+шуморо огоҳ мекунад ва кушодани сайти луғатро пешниҳод мекунад.</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="1019"/>
+        <source>Check for new program releases periodically</source>
+        <translation>Мавҷуд будани версияи навро такроран тафтиш кунед</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="1040"/>
+        <source>Ad&amp;vanced</source>
+        <translation>&amp;Иловагӣ</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="1046"/>
+        <source>ScanPopup extra technologies</source>
+        <translation>Технологияҳои тарҷумаи пайдошавандаи иловагӣ</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="1052"/>
+        <source>Try to use IAccessibleEx technology to retrieve word under cursor.
+This technology works only with some programs that support it
+ (for example Internet Explorer 9).
+It is not needed to select this option if you don&apos;t use such programs.</source>
+        <translation>Барои тарҷума кардани калимаҳои зери курсор, технологияи IAccessibleEx-ро истифода баред.
+Ин технология танҳо бо баъзе барномаҳои дастгиришаванда кор мекунад (масалан Internet Explorer 9).
+Агар шумо чунин барномаҳо истифода намебаред, имконоти зеринро истифода набаред.</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="1058"/>
+        <source>Use &amp;IAccessibleEx</source>
+        <translation>&amp;IAccessibleEx-ро истифода баред</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="1065"/>
+        <source>Try to use UI Automation technology to retrieve word under cursor.
+This technology works only with some programs that support it.
+It is not needed to select this option if you don&apos;t use such programs.</source>
+        <translation>Барои тарҷума кардани калимаҳои зери курсор, технологияи  UI Automation-ро истифода баред.
+Ин технология танҳо бо баъзе барномаҳои дастгиришаванда кор мекунад.
+Агар шумо чунин барномаҳо истифода намебаред, имконоти зеринро истифода набаред.</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="1070"/>
+        <source>Use &amp;UIAutomation</source>
+        <translation>&amp;UIAutomation-ро истифода баред</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="1077"/>
+        <source>Try to use special GoldenDict message to retrieve word under cursor.
+This technology works only with some programs that support it.
+It is not needed to select this option if you don&apos;t use such programs.</source>
+        <translation>Барои тарҷума кардани калимаҳои зери курсор, дархости махсуси GoldenDict-ро истифода баред.
+Ин технология танҳо бо баъзе барномаҳои дастгиришаванда кор мекунад.
+Агар шумо чунин барномаҳо истифода намебаред, имконоти зеринро истифода набаред.</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="1082"/>
+        <source>Use &amp;GoldenDict message</source>
+        <translation>&amp;Дархости GoldenDict-ро истифода баред</translation>
+    </message>
+    <message>
+        <location filename="../preferences.cc" line="41"/>
+        <source>System default</source>
+        <translation>Системаи пешфарз</translation>
+    </message>
+    <message>
+        <location filename="../preferences.cc" line="79"/>
+        <source>Default</source>
+        <translation>Пешфарз</translation>
+    </message>
+    <message>
+        <location filename="../preferences.cc" line="80"/>
+        <source>Lingvo</source>
+        <translation>Луғати Lingvo</translation>
+    </message>
+    <message>
+        <location filename="../preferences.cc" line="81"/>
+        <source>Babylon</source>
+        <translation>Луғати Babylon</translation>
+    </message>
+    <message>
+        <location filename="../preferences.cc" line="152"/>
+        <source>Play via DirectShow</source>
+        <translation>Ба воситаи DirectShow иҷро кунед</translation>
+    </message>
+    <message>
+        <location filename="../preferences.cc" line="337"/>
+        <source>Changing Language</source>
+        <translation>Забонро иваз кунед</translation>
+    </message>
+    <message>
+        <location filename="../preferences.cc" line="338"/>
+        <source>Restart the program to apply the language change.</source>
+        <translation>Барои татбиқ кардани забони интихобшуда барномаро аз нав оғоз кунед.</translation>
+    </message>
+</context>
+<context>
+    <name>ProgramTypeEditor</name>
+    <message>
+        <location filename="../sources.cc" line="772"/>
+        <source>Audio</source>
+        <translation>Аудио</translation>
+    </message>
+    <message>
+        <location filename="../sources.cc" line="774"/>
+        <source>Plain Text</source>
+        <translation>Матни оддӣ</translation>
+    </message>
+    <message>
+        <location filename="../sources.cc" line="776"/>
+        <source>Html</source>
+        <translation>Html</translation>
+    </message>
+    <message>
+        <location filename="../sources.cc" line="778"/>
+        <source>Prefix Match</source>
+        <translation>Аз рӯи префикс</translation>
+    </message>
+    <message>
+        <location filename="../sources.cc" line="780"/>
+        <source>Unknown</source>
+        <translation>Номаълум</translation>
+    </message>
+</context>
+<context>
+    <name>Programs::RunInstance</name>
+    <message>
+        <location filename="../programs.cc" line="152"/>
+        <source>No program name was given.</source>
+        <translation>Ягон номи барнома муайян нашуд.</translation>
+    </message>
+    <message>
+        <location filename="../programs.cc" line="168"/>
+        <source>The program has crashed.</source>
+        <translation>Барнома вайрон шуд.</translation>
+    </message>
+    <message>
+        <location filename="../programs.cc" line="171"/>
+        <source>The program has returned exit code %1.</source>
+        <translation>Барнома маънои %1-ро намоиш дод.</translation>
+    </message>
+</context>
+<context>
+    <name>ProgramsModel</name>
+    <message>
+        <location filename="../sources.cc" line="688"/>
+        <source>Enabled</source>
+        <translation>Фаъолшуда</translation>
+    </message>
+    <message>
+        <location filename="../sources.cc" line="690"/>
+        <source>Type</source>
+        <translation>Намуд</translation>
+    </message>
+    <message>
+        <location filename="../sources.cc" line="692"/>
+        <source>Name</source>
+        <translation>Ном</translation>
+    </message>
+    <message>
+        <location filename="../sources.cc" line="694"/>
+        <source>Command Line</source>
+        <translation>Сатри иҷрои фармон</translation>
+    </message>
+</context>
+<context>
+    <name>Romaji</name>
+    <message>
+        <location filename="../romaji.cc" line="107"/>
+        <source>Hepburn Romaji for Hiragana</source>
+        <translation>Системаи Хэпбёрни Ромаҷӣ барои Хирагана</translation>
+    </message>
+    <message>
+        <location filename="../romaji.cc" line="116"/>
+        <source>Hepburn Romaji for Katakana</source>
+        <translation>Системаи Хэпбёрни Ромаҷӣ барои Катакана</translation>
+    </message>
+</context>
+<context>
+    <name>RussianTranslit</name>
+    <message>
+        <location filename="../russiantranslit.cc" line="107"/>
+        <source>Russian Transliteration</source>
+        <translation>Транслитератсияи русӣ</translation>
+    </message>
+</context>
+<context>
+    <name>ScanPopup</name>
+    <message>
+        <location filename="../scanpopup.ui" line="14"/>
+        <source>Dialog</source>
+        <translation>Диалог</translation>
+    </message>
+    <message>
+        <location filename="../scanpopup.ui" line="60"/>
+        <source>word</source>
+        <translation>калима</translation>
+    </message>
+    <message>
+        <location filename="../scanpopup.ui" line="67"/>
+        <source>List Matches (Alt+M)</source>
+        <translation>Рӯйхати мувофиқатҳо (Alt+M)</translation>
+    </message>
+    <message>
+        <location filename="../scanpopup.ui" line="70"/>
+        <location filename="../scanpopup.ui" line="93"/>
+        <location filename="../scanpopup.ui" line="143"/>
+        <location filename="../scanpopup.ui" line="167"/>
+        <source>...</source>
+        <translation>...</translation>
+    </message>
+    <message>
+        <location filename="../scanpopup.ui" line="83"/>
+        <source>Alt+M</source>
+        <translation>Alt+M</translation>
+    </message>
+    <message>
+        <location filename="../scanpopup.ui" line="90"/>
+        <source>Pronounce Word (Alt+S)</source>
+        <translation>Калимаро талаффуз кунед (Alt+S)</translation>
+    </message>
+    <message>
+        <location filename="../scanpopup.ui" line="100"/>
+        <source>Alt+S</source>
+        <translation>Alt+S</translation>
+    </message>
+    <message>
+        <location filename="../scanpopup.ui" line="110"/>
+        <source>Send word to main window (Alt+W)</source>
+        <translation>Калимаро ба тирезаи асосӣ гузоред (Alt+W)</translation>
+    </message>
+    <message>
+        <location filename="../scanpopup.ui" line="120"/>
+        <source>Alt+W</source>
+        <translation>Alt+W</translation>
+    </message>
+    <message>
+        <location filename="../scanpopup.ui" line="140"/>
+        <source>Shows or hides the dictionary bar</source>
+        <translation>Лавҳаи луғатро пинҳон ё нишон медиҳад</translation>
+    </message>
+    <message>
+        <location filename="../scanpopup.ui" line="163"/>
+        <source>Use this to pin down the window so it would stay on screen,
+could be resized or managed in other ways.</source>
+        <translation>Барои мустаҳкам кардан тиреза дар экран, иваз кардани ҳаҷм,
+ё идоракунии хусусиятҳои дигар инро зер кунед.</translation>
+    </message>
+</context>
+<context>
+    <name>SoundDirsModel</name>
+    <message>
+        <location filename="../sources.cc" line="970"/>
+        <source>Path</source>
+        <translation>Роҳ</translation>
+    </message>
+    <message>
+        <location filename="../sources.cc" line="972"/>
+        <source>Name</source>
+        <translation>Ном</translation>
+    </message>
+</context>
+<context>
+    <name>Sources</name>
+    <message>
+        <location filename="../sources.ui" line="34"/>
+        <source>Files</source>
+        <translation>Файлҳо</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="40"/>
+        <source>Paths to search for the dictionary files:</source>
+        <translation>Ҷойҳо барои ҷустуҷӯи файлҳои луғат:</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="54"/>
+        <location filename="../sources.ui" line="117"/>
+        <location filename="../sources.ui" line="241"/>
+        <location filename="../sources.ui" line="300"/>
+        <location filename="../sources.ui" line="366"/>
+        <source>&amp;Add...</source>
+        <translation>&amp;Илова кунед...</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="61"/>
+        <location filename="../sources.ui" line="124"/>
+        <location filename="../sources.ui" line="248"/>
+        <location filename="../sources.ui" line="307"/>
+        <location filename="../sources.ui" line="373"/>
+        <source>&amp;Remove</source>
+        <translation>&amp;Тоза кунед</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="81"/>
+        <source>Re&amp;scan now</source>
+        <translation>&amp;Аз нав коркард кунед</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="97"/>
+        <source>Sound Dirs</source>
+        <translation>Ҷузвдони овоздор</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="103"/>
+        <source>Make dictionaries from bunches of audiofiles by adding paths here:</source>
+        <translation>Луғатҳоро аз файлҳои аудиоӣ (овоздор) эҷод кунед. Ҷои файлҳои аудиоиро илова кунед:</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="153"/>
+        <source>Morphology</source>
+        <translation>Морфология</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="159"/>
+        <source>Path to a directory with Hunspell/Myspell dictionaries:</source>
+        <translation>Ҷой феҳрист бо луғатҳои Hunspell/Myspel:</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="175"/>
+        <source>&amp;Change...</source>
+        <translation>&amp;Таъғир диҳед...</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="184"/>
+        <source>Available morphology dictionaries:</source>
+        <translation>Луғатҳои морфологияи дастоас:</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="196"/>
+        <source>Each morphology dictionary appears as a
+separate auxiliary dictionary which
+provides stem words for searches and
+spelling suggestions for mistyped words.
+Add appropriate dictionaries to the bottoms
+of the appropriate groups to use them.</source>
+        <translation>Ҳар як луғати морфология ҳамчун луғати иловагии
+ягона истифода мешавад ва решаҳои калимаҳои
+нодуруст воридшуда ва вариантҳои навиштанашро
+ҳангоми ҷустуҷӯ намоиш медиҳад.
+Барои истифода кардани луғатҳои муносиб онҳоро
+ба поёни рӯйхати гурӯҳҳои муносиб илова кунед.</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="221"/>
+        <source>Wikipedia</source>
+        <translation>Wikipedia</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="227"/>
+        <source>Wikipedia (MediaWiki) sites:</source>
+        <translation>Сайтҳои Wikipedia (MediaWiki):</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="280"/>
+        <source>Websites</source>
+        <translation>Вебсайтҳо</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="286"/>
+        <source>Any websites. A string %GDWORD% will be replaced with the query word:</source>
+        <translation>Ҳамаи вебсайтҳо. Сатри %GDWORD% бо калимаи воридшуда ҷойиваз мешавад:</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="331"/>
+        <source>Alternatively, use %GD1251% for CP1251, %GDISO1% for ISO 8859-1.</source>
+        <translation>Шумо ҳамчун метавонед сатри %GD1251%-ро барои рамзгузории CP1251 истифода баред. Сатри %GDISO1% барои рамзгузории ISO 8859-1 истифода мешавад.</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="343"/>
+        <source>Programs</source>
+        <translation>Барномаҳо</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="349"/>
+        <source>Any external programs. A string %GDWORD% will be replaced with the query word. The word will also be fed into standard input.</source>
+        <translation>Ҳамаи барномаҳои берунӣ. Сатри %GDWORD% бо калимаи дархостшуда ҷойиваз мешавад. Ҳамон калима ҳам ба сатри вуруди калимаҳо ворид мешавад.</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="402"/>
+        <source>Forvo</source>
+        <translation>Forvo</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="414"/>
+        <source>Live pronunciations from &lt;a href=&quot;http://www.forvo.com/&quot;&gt;forvo.com&lt;/a&gt;. The site allows people to record and share word pronunciations. You can listen to them from GoldenDict.</source>
+        <translation>Талаффузи фаврӣ аз &lt;a href=&quot;http://www.forvo.com/&quot;&gt;forvo.com&lt;/a&gt;. Вебсайти зерин ба одамон иҷозат медиҳад, ки онҳо тавонанд талаффузи калимаҳоро сабт ва пахш  кунанд. Шумо метавонед калимаҳои сабтшударо аз луғати GoldenDict гӯш кунед.</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="427"/>
+        <source>Enable pronunciations from Forvo</source>
+        <translation>Талаффузро аз Forvo фаъол кунед</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="457"/>
+        <source>API Key:</source>
+        <translation>Калиди API:</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="464"/>
+        <source>Use of Forvo currently requires an API key. Leave this field
+blank to use the default key, which may become unavailable
+in the future, or register on the site to get your own key.</source>
+        <translation>Барои истифодабарии хадамоти Forvo калиди API лозим аст. Сатри зеринро холӣ монед,
+агар шумо мехоҳед калиди пешфарзро истифода баред, вале калиди пешфарз метавонад дар
+оянда дастнорас шавад, барои ин шумо метавонед калиди шихсиро дар вебсайт дархост кунед.</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="489"/>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;table style=&quot;-qt-table-type: root; margin-top:4px; margin-bottom:4px; margin-left:4px; margin-right:4px;&quot;&gt;
+&lt;tr&gt;
+&lt;td style=&quot;border: none;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Get your own key &lt;a href=&quot;http://api.forvo.com/key/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0057ae;&quot;&gt;here&lt;/span&gt;&lt;/a&gt;, or leave blank to use the default one.&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;table style=&quot;-qt-table-type: root; margin-top:4px; margin-bottom:4px; margin-left:4px; margin-right:4px;&quot;&gt;
+&lt;tr&gt;
+&lt;td style=&quot;border: none;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Калиди шахсиро аз &lt;a href=&quot;http://api.forvo.com/key/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0057ae;&quot;&gt;ин ҷо&lt;/span&gt;&lt;/a&gt; дархост кунед, ё инро холӣ монед барои он ки тавонед калиди пешфарзро истифода баред.&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="509"/>
+        <source>Language codes (comma-separated):</source>
+        <translation>Рамзҳои забон (бо вергул ҷудо мешаванд):</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="516"/>
+        <source>List of language codes you would like to have. Example: &quot;en, ru&quot;.</source>
+        <translation>Рӯйхати рамзҳои забоне, ки шумо мехоҳед дар бар гиред. Масалан: &quot;en, tg&quot;.</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="539"/>
+        <source>Full list of language codes is available &lt;a href=&quot;http://www.forvo.com/languages-codes/&quot;&gt;here&lt;/a&gt;.</source>
+        <translation>Рӯйхати рамзҳои забонҳои пур дар &lt;a href=&quot;http://www.forvo.com/languages-codes/&quot;&gt;ин ҷо&lt;/a&gt; дастрас аст.</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="581"/>
+        <source>Transliteration</source>
+        <translation>Транслитератсия</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="602"/>
+        <source>Russian transliteration</source>
+        <translation>Транслитератсияи русӣ</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="613"/>
+        <source>Greek transliteration</source>
+        <translation>Транслитератсияи юнонӣ</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="637"/>
+        <source>German transliteration</source>
+        <translation>Транслитератсияи олмонӣ</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="663"/>
+        <source>Enables to use the Latin alphabet to write the Japanese language</source>
+        <translation>Барои навиштан дар забони ҷопонӣ, истифодаи алифбои лотиниро фаъол мекунад</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="666"/>
+        <source>Japanese Romaji</source>
+        <translation>Ромаҷии ҷопонӣ</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="678"/>
+        <source>Systems:</source>
+        <translation>Системаҳо:</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="685"/>
+        <source>The most widely used method of transcription of Japanese,
+based on English phonology</source>
+        <translation>Машҳуртарин тарзи транскрипткунонии калимаҳои Ҷопонӣ
+дар асоси фонологияи Англисӣ иҷро мешавад</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="689"/>
+        <source>Hepburn</source>
+        <translation>Хэпбёрн</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="699"/>
+        <source>The most regular system, having a one-to-one relation to the
+kana writing systems. Standardized as ISO 3602
+
+Not implemented yet in GoldenDict.</source>
+        <translation>Системаи мувофиқтарин барои навиштан бо скриптҳои Кана.
+Дар асоси стандарти ISO 3602 эҷод шудааст.
+
+Системаи дар боло зикршуда ҳоло дар луғати GoldenDict вуҷуд надорад.</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="705"/>
+        <source>Nihon-shiki</source>
+        <translation>Ниҳон-шикӣ</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="715"/>
+        <source>Based on Nihon-shiki system, but modified for modern standard Japanese.
+Standardized as ISO 3602
+
+Not implemented yet in GoldenDict.</source>
+        <translation>Дорои системаи Нихон-шикӣ мебошад, вале барои забони Ҷопонии стандартии
+ҳозиразамон тағйир дода шуд. Дар асоси стандарти ISO 3602 эҷод шудааст.
+
+Системаи дар боло зикршуда ҳоло дар луғати GoldenDict вуҷуд надорад.</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="721"/>
+        <source>Kunrei-shiki</source>
+        <translation>Канрей-шикӣ</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="728"/>
+        <source>Syllabaries:</source>
+        <translation>Алифбои ҳиҷо:</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="735"/>
+        <source>Hiragana Japanese syllabary</source>
+        <translation>Алифбои ҳиҷои Хираганаи ҷопонӣ</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="738"/>
+        <source>Hiragana</source>
+        <translation>Хирагана</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="745"/>
+        <source>Katakana Japanese syllabary</source>
+        <translation>Алифбои ҳиҷои Катаканаи ҷопонӣ</translation>
+    </message>
+    <message>
+        <location filename="../sources.ui" line="748"/>
+        <source>Katakana</source>
+        <translation>Катакана</translation>
+    </message>
+    <message>
+        <location filename="../sources.cc" line="104"/>
+        <source>(not available in portable version)</source>
+        <translation>(дар версияи кӯчондашаванда дастрас нест)</translation>
+    </message>
+    <message>
+        <location filename="../sources.cc" line="140"/>
+        <location filename="../sources.cc" line="167"/>
+        <location filename="../sources.cc" line="194"/>
+        <source>Choose a directory</source>
+        <translation>Ҷузвдонро интихоб кунед</translation>
+    </message>
+    <message>
+        <location filename="../sources.cc" line="154"/>
+        <location filename="../sources.cc" line="181"/>
+        <location filename="../sources.cc" line="221"/>
+        <location filename="../sources.cc" line="245"/>
+        <location filename="../sources.cc" line="269"/>
+        <source>Confirm removal</source>
+        <translation>Тозакуниро тасдиқ кунед</translation>
+    </message>
+    <message>
+        <location filename="../sources.cc" line="155"/>
+        <location filename="../sources.cc" line="182"/>
+        <source>Remove directory &lt;b&gt;%1&lt;/b&gt; from the list?</source>
+        <translation>Ҷузвдони &lt;b&gt;%1&lt;/b&gt;-ро аз рӯйхат тоза мекунед?</translation>
+    </message>
+    <message>
+        <location filename="../sources.cc" line="222"/>
+        <location filename="../sources.cc" line="246"/>
+        <source>Remove site &lt;b&gt;%1&lt;/b&gt; from the list?</source>
+        <translation>Вебсайти &lt;b&gt;%1&lt;/b&gt;-ро аз рӯйхат тоза мекунед?</translation>
+    </message>
+    <message>
+        <location filename="../sources.cc" line="270"/>
+        <source>Remove program &lt;b&gt;%1&lt;/b&gt; from the list?</source>
+        <translation>Барномаи &lt;b&gt;%1&lt;/b&gt;-ро аз рӯйхат тоза мекунед?</translation>
+    </message>
+</context>
+<context>
+    <name>WebSitesModel</name>
+    <message>
+        <location filename="../sources.cc" line="539"/>
+        <source>Enabled</source>
+        <translation>Фаъолшуда</translation>
+    </message>
+    <message>
+        <location filename="../sources.cc" line="541"/>
+        <source>Name</source>
+        <translation>Ном</translation>
+    </message>
+    <message>
+        <location filename="../sources.cc" line="543"/>
+        <source>Address</source>
+        <translation>Суроға</translation>
+    </message>
+</context>
+<context>
+    <name>WordFinder</name>
+    <message>
+        <location filename="../wordfinder.cc" line="170"/>
+        <source>Failed to query some dictionaries.</source>
+        <translation>Дархости баъзе луғатҳо қатъ карда шуд.</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
New language added to GoldenDict. Tajik translation was committed to goldendict/locale/tg_TJ.ts.
