### PR TITLE
NoIframe website dictionary-Use QWebPage

### DIFF
--- a/article-style-print.css
+++ b/article-style-print.css
@@ -2,7 +2,7 @@
 
 body
 {
-  background: white;
+  background: white!important; /*fix for noiframe website style*/;
 }
 
 /* Hide audio icons */

--- a/article-style-st-babylon.css
+++ b/article-style-st-babylon.css
@@ -1,6 +1,6 @@
 body
 {
-	background: white;
+	background: white!important; /*fix for noiframe website style*/;
 	font-size: 13px;
 }
 

--- a/article-style-st-lingvo.css
+++ b/article-style-st-lingvo.css
@@ -1,6 +1,6 @@
 body
 {
-  background: white;
+  background: white!important; /*fix for noiframe website style*/;
 }
 
 a
@@ -73,7 +73,7 @@ a:hover
   clear: both;
 }
 
-.gddictname + h3, .gddictname + .dsl_article > .dsl_headwords
+.gddictname + h3, .gddictname + .dsl_article > .dsl_headwords, .website_term
 {
   margin-top: 10px;
 }

--- a/article-style.css
+++ b/article-style.css
@@ -2,7 +2,7 @@
 
 body
 {
-  background: #fefdeb;
+  background: #fefdeb!important; /*fix for noiframe website style*/
   font-family: Tahoma, Verdana, "Lucida Sans Unicode", sans-serif;
   font-size: 13px;
 }
@@ -2651,3 +2651,11 @@ in bg url to hide it from iemac */
 .mwiki .infl-table { display: none }
 /****default hide dict icon ***/
 .gddicticon{display:none;}
+/**noiframe website**/
+.website_article{}
+.website_article .website_term
+{
+	font-weight: bold!important;
+	margin: 10px;
+	font-size: 15px!important;
+}

--- a/article_netmgr.cc
+++ b/article_netmgr.cc
@@ -44,6 +44,24 @@ namespace
   }
 }
 
+bool ArticleNetworkAccessManager::RelativeUrl2Absolute( QUrl &url, QUrl const &baseurl )
+{
+    if(url.scheme().isEmpty())
+    {
+        if(url.host().isEmpty())
+        {
+            if(url.toString().indexOf("/")!=0)
+            {
+                url.setPath(baseurl.path().left(baseurl.path().lastIndexOf("/"))+"/"+url.path());
+            }
+            url.setHost(baseurl.host());
+        }
+        url.setScheme(baseurl.scheme());
+        return true;
+    }
+    return false;
+}
+
 QNetworkReply * ArticleNetworkAccessManager::createRequest( Operation op,
                                                             QNetworkRequest const & req,
                                                             QIODevice * outgoingData )
@@ -71,6 +89,12 @@ QNetworkReply * ArticleNetworkAccessManager::createRequest( Operation op,
 
     if ( dr.get() )
       return new ArticleResourceReply( this, req, dr, contentType );
+    if ( req.url().hasQueryItem( POSTQUERYITEM ) )
+    {
+        QNetworkRequest postReq( req );
+        postReq.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded" );
+        return QNetworkAccessManager::post ( postReq , postReq.url().encodedQuery() );
+    }
   }
 
   // Check the Referer. If the user has opted-in to block elements from external

--- a/article_netmgr.hh
+++ b/article_netmgr.hh
@@ -7,7 +7,6 @@
 #include <QtNetwork>
 #include "dictionary.hh"
 #include "article_maker.hh"
-
 using std::vector;
 
 /// A custom QNetworkAccessManager version which fetches images from the
@@ -37,7 +36,7 @@ public:
   /// The function can optionally set the Content-Type header correspondingly.
   sptr< Dictionary::DataRequest > getResource( QUrl const & url,
                                                QString & contentType );
-
+  static bool RelativeUrl2Absolute( QUrl &url, QUrl const &baseurl );
 protected:
 
   virtual QNetworkReply * createRequest( Operation op,

--- a/config.cc
+++ b/config.cc
@@ -551,6 +551,14 @@ Class load() throw( exError )
       w.name = ws.attribute( "name" );
       w.url = ws.attribute( "url" );
       w.enabled = ( ws.attribute( "enabled" ) == "1" );
+      w.resultselectors = ws.attribute( "resultselectors" );
+      w.noresulttext = ws.attribute( "noresulttext" );
+      w.filter = ws.attribute( "filter" );
+      w.icon = ws.attribute( "icon" );
+      w.customcss = ws.attribute( "customcss" );
+      w.fromlang = ws.attribute( "fromlang" );
+      w.tolang = ws.attribute( "tolang" );
+      w.usepost = ( ws.attribute( "usepost" ) == "1" );
 
       c.webSites.push_back( w );
     }
@@ -975,6 +983,38 @@ void save( Class const & c ) throw( exError )
       QDomAttr enabled = dd.createAttribute( "enabled" );
       enabled.setValue( i->enabled ? "1" : "0" );
       ws.setAttributeNode( enabled );
+
+      QDomAttr rslt = dd.createAttribute( "resultselectors" );
+      rslt.setValue( i->resultselectors );
+      ws.setAttributeNode( rslt );
+
+      QDomAttr nrslt = dd.createAttribute( "noresulttext" );
+      nrslt.setValue( i->noresulttext );
+      ws.setAttributeNode( nrslt );
+
+      QDomAttr fltr = dd.createAttribute( "filter" );
+      fltr.setValue( i->filter );
+      ws.setAttributeNode( fltr );
+
+      QDomAttr ico = dd.createAttribute( "icon" );
+      ico.setValue( i->icon );
+      ws.setAttributeNode( ico );
+
+      QDomAttr css = dd.createAttribute( "customcss" );
+      css.setValue( i->customcss );
+      ws.setAttributeNode( css );
+
+      QDomAttr flng = dd.createAttribute( "fromlang" );
+      flng.setValue( i->fromlang );
+      ws.setAttributeNode( flng );
+
+      QDomAttr tlng = dd.createAttribute( "tolang" );
+      tlng.setValue( i->tolang );
+      ws.setAttributeNode( tlng );
+
+      QDomAttr upost = dd.createAttribute( "usepost" );
+      upost.setValue( i->usepost? "1":"0" );
+      ws.setAttributeNode( upost );
     }
   }
 

--- a/config.hh
+++ b/config.hh
@@ -206,19 +206,30 @@ struct MediaWiki
 /// Any website which can be queried though a simple template substitution
 struct WebSite
 {
-  QString id, name, url;
-  bool enabled;
+  QString id, name, url, resultselectors, noresulttext, filter, icon, customcss, fromlang, tolang;
+  bool enabled, usepost;
 
-  WebSite(): enabled( false )
+  WebSite(): enabled( false ), usepost( false )
   {}
 
   WebSite( QString const & id_, QString const & name_, QString const & url_,
-           bool enabled_ ):
-    id( id_ ), name( name_ ), url( url_ ), enabled( enabled_ ) {}
+           bool enabled_, QString const & resultselectors_ = "style,body", QString const noresulttext_="",
+           QString const & filter_="", QString const icon_="",
+           QString const & customcss_="",
+          bool usepost_ =  false, QString  const & fromlang_="", QString const & toLang_=""  ):
+    id( id_ ), name( name_ ), url( url_ ), enabled( enabled_ ),
+      resultselectors( resultselectors_ ), noresulttext( noresulttext_ ),
+      filter( filter_ ), icon( icon_ ), customcss( customcss_ ),
+      usepost( usepost_ ),
+      fromlang( fromlang_ ), tolang( toLang_ ){}
 
   bool operator == ( WebSite const & other ) const
   { return id == other.id && name == other.name && url == other.url &&
-           enabled == other.enabled; }
+           enabled == other.enabled && usepost == other.usepost &&
+              resultselectors == other.resultselectors && noresulttext == other.noresulttext &&
+              filter == other.filter && customcss == other.customcss &&
+              icon == other.icon
+              && fromlang == other.fromlang && tolang == other.tolang; }
 };
 
 /// All the WebSites

--- a/dictionary.hh
+++ b/dictionary.hh
@@ -13,7 +13,9 @@
 #include "ex.hh"
 #include "mutex.hh"
 #include "wstring.hh"
-
+#ifndef POSTQUERYITEM
+#define POSTQUERYITEM "gdpost"
+#endif
 /// Abstract dictionary-related stuff
 namespace Dictionary {
 

--- a/sources.cc
+++ b/sources.cc
@@ -46,6 +46,14 @@ Sources::Sources( QWidget * parent, Config::Paths const & paths,
   ui.webSites->resizeColumnToContents( 0 );
   ui.webSites->resizeColumnToContents( 1 );
   ui.webSites->resizeColumnToContents( 2 );
+  ui.webSites->resizeColumnToContents( 3 );
+  ui.webSites->resizeColumnToContents( 4 );
+  ui.webSites->resizeColumnToContents( 5 );
+  ui.webSites->resizeColumnToContents( 6 );
+  ui.webSites->resizeColumnToContents( 7 );
+  ui.webSites->resizeColumnToContents( 8 );
+  ui.webSites->resizeColumnToContents( 9 );
+  ui.webSites->resizeColumnToContents( 10 );
 
   ui.programs->setTabKeyNavigation( true );
   ui.programs->setModel( &programsModel );
@@ -484,6 +492,9 @@ void WebSitesModel::addNewSite()
 
   w.url = "http://";
 
+  w.resultselectors ="style,body,link[rel=stylesheet]";
+  w.filter = "script";
+
   beginInsertRows( QModelIndex(), webSites.size(), webSites.size() );
   webSites.push_back( w );
   endInsertRows();
@@ -505,7 +516,7 @@ Qt::ItemFlags WebSitesModel::flags( QModelIndex const & index ) const
 
   if ( index.isValid() )
   {
-    if ( !index.column() )
+    if ( !index.column() || index.column() == 10 )
       result |= Qt::ItemIsUserCheckable;
     else
       result |= Qt::ItemIsEditable;
@@ -527,7 +538,7 @@ int WebSitesModel::columnCount( QModelIndex const & parent ) const
   if ( parent.isValid() )
     return 0;
   else
-    return 3;
+    return 11;// 3;
 }
 
 QVariant WebSitesModel::headerData( int section, Qt::Orientation /*orientation*/, int role ) const
@@ -541,6 +552,22 @@ QVariant WebSitesModel::headerData( int section, Qt::Orientation /*orientation*/
         return tr( "Name" );
       case 2:
         return tr( "Address" );
+    case 3:
+        return tr( "Result Selectors" );
+    case 4:
+        return tr( "NoResult Text" );
+    case 5:
+        return tr( "Filters" );
+    case 6:
+        return tr( "Icon" );
+    case 7:
+        return tr( "Css File" );
+    case 8:
+        return tr( "From Language" );
+    case 9:
+        return tr( "To Language" );
+    case 10:
+        return tr( "Post Method" );
       default:
         return QVariant();
     }
@@ -561,13 +588,32 @@ QVariant WebSitesModel::data( QModelIndex const & index, int role ) const
         return webSites[ index.row() ].name;
       case 2:
         return webSites[ index.row() ].url;
+    case 3:
+         return webSites[ index.row() ].resultselectors;
+    case 4:
+        return webSites[ index.row() ].noresulttext;
+    case 5:
+        return webSites[ index.row() ].filter;
+    case 6:
+         return webSites[ index.row() ].icon;
+    case 7:
+        return webSites[ index.row() ].customcss;
+   case 8:
+        return webSites[ index.row() ].fromlang;
+    case 9:
+        return webSites[ index.row() ].tolang;
       default:
         return QVariant();
     }
   }
 
-  if ( role == Qt::CheckStateRole && !index.column() )
-    return webSites[ index.row() ].enabled;
+  if ( role == Qt::CheckStateRole)
+  {
+    if(!index.column() )
+        return webSites[ index.row() ].enabled;
+    else if( index.column() == 10)
+        return webSites[ index.row() ].usepost;
+  }
 
   return QVariant();
 }
@@ -578,16 +624,24 @@ bool WebSitesModel::setData( QModelIndex const & index, const QVariant & value,
   if ( (unsigned)index.row() >= webSites.size() )
     return false;
 
-  if ( role == Qt::CheckStateRole && !index.column() )
+  if ( role == Qt::CheckStateRole) // &&  )
   {
     //DPRINTF( "type = %d\n", (int)value.type() );
     //DPRINTF( "value = %d\n", (int)value.toInt() );
 
     // XXX it seems to be always passing Int( 2 ) as a value, so we just toggle
-    webSites[ index.row() ].enabled = !webSites[ index.row() ].enabled;
-
-    dataChanged( index, index );
-    return true;
+      if(!index.column())
+      {
+        webSites[ index.row() ].enabled = !webSites[ index.row() ].enabled;
+        dataChanged( index, index );
+        return true;
+      }
+      else if( index.column() == 10)
+      {
+          webSites[ index.row() ].usepost = !webSites[ index.row() ].usepost;
+          dataChanged( index, index );
+          return true;
+      }
   }
 
   if ( role == Qt::DisplayRole || role == Qt::EditRole )
@@ -599,6 +653,34 @@ bool WebSitesModel::setData( QModelIndex const & index, const QVariant & value,
         return true;
       case 2:
         webSites[ index.row() ].url =  value.toString();
+        dataChanged( index, index );
+        return true;
+    case 3:
+        webSites[ index.row() ].resultselectors =  value.toString();
+        dataChanged( index, index );
+         return true;
+    case 4:
+        webSites[ index.row() ].noresulttext =  value.toString();
+        dataChanged( index, index );
+        return true;
+    case 5:
+        webSites[ index.row() ].filter =  value.toString();
+        dataChanged( index, index );
+        return true;
+    case 6:
+        webSites[ index.row() ].icon =  value.toString();
+        dataChanged( index, index );
+         return true;
+    case 7:
+        webSites[ index.row() ].customcss =  value.toString();
+        dataChanged( index, index );
+        return true;
+    case 8:
+        webSites[ index.row() ].fromlang =  value.toString();
+        dataChanged( index, index );
+        return true;
+    case 9:
+        webSites[ index.row() ].tolang =  value.toString();
         dataChanged( index, index );
         return true;
       default:

--- a/website.cc
+++ b/website.cc
@@ -6,7 +6,13 @@
 #include "utf8.hh"
 #include <QUrl>
 #include <QTextCodec>
-
+#include <QFileInfo>
+#include "langcoder.hh"
+#include <QWebFrame>
+#include <QWebElement>
+#include "article_netmgr.hh"
+#include "htmlescape.hh"
+#include "filetype.hh"
 namespace WebSite {
 
 using namespace Dictionary;
@@ -17,14 +23,23 @@ class WebSiteDictionary: public Dictionary::Class
 {
   string name;
   QByteArray urlTemplate;
-
+  QString resultselectors, noresulttext, filter, icon, customcss, fromlang, tolang;
+  bool usePost;
 public:
 
   WebSiteDictionary( string const & id, string const & name_,
-                     QString const & urlTemplate_ ):
+                     QString const & urlTemplate_ , QString const & resultselectors_,
+                     QString const & noresulttext_, QString const & filter_,
+                     QString const & icon_, QString const & customcss_,
+                     QString const & fromlang_,
+                     QString const & tolang_, bool usePost_):
     Dictionary::Class( id, vector< string >() ),
-    name( name_ ),
-    urlTemplate( QUrl( urlTemplate_ ).toEncoded() )
+      name( name_ ), resultselectors( resultselectors_ ),
+      noresulttext( noresulttext_ ), filter( filter_ ),
+      icon( icon_ ), customcss( customcss_ ),
+      fromlang( fromlang_ ),
+      tolang( tolang_ ), usePost( usePost_ ),
+    urlTemplate( QUrl( urlTemplate_ ).toEncoded())
   {
   }
 
@@ -41,7 +56,21 @@ public:
   { return 0; }
 
   virtual QIcon getIcon() throw()
-  { return QIcon(":/icons/internet.png"); }
+  {
+      if( !icon.isNull() && !icon.isEmpty() )
+      {
+          QFileInfo fInfo(  QDir( Config::getConfigDir() ), icon );
+          if( fInfo.isFile() )
+              return QIcon( fInfo.absoluteFilePath() );
+      }
+      return QIcon(":/icons/internet.png");
+  }
+  virtual quint32 getLangFrom() const
+  { return LangCoder::code3toInt( fromlang.toStdString() ); }
+
+  /// Returns the dictionary's target language.
+  virtual quint32 getLangTo() const
+  { return LangCoder::code3toInt( tolang.toStdString() ); }
 
   virtual sptr< WordSearchRequest > prefixMatch( wstring const & word,
                                                  unsigned long ) throw( std::exception );
@@ -67,7 +96,6 @@ sptr< DataRequest > WebSiteDictionary::getArticle( wstring const & str,
                                                    wstring const & context )
   throw( std::exception )
 {
-  sptr< DataRequestInstant > dr = new DataRequestInstant( true );
 
   QByteArray urlString;
 
@@ -78,6 +106,16 @@ sptr< DataRequest > WebSiteDictionary::getArticle( wstring const & str,
   {
     urlString = urlTemplate;
 
+    if( usePost && resultselectors.isEmpty() )
+    {
+        QUrl url = QUrl::fromEncoded( urlString );
+        if( !url.hasQueryItem( POSTQUERYITEM ) )
+        {
+            url.addQueryItem( POSTQUERYITEM, "true" );
+            urlString = url.toEncoded();
+        }
+
+    }
     QString inputWord = gd::toQString( str );
 
     urlString.replace( "%25GDWORD%25", inputWord.toUtf8().toPercentEncoding() );
@@ -98,22 +136,34 @@ sptr< DataRequest > WebSiteDictionary::getArticle( wstring const & str,
     }
   }
 
-  string result = "<div class=\"website_padding\"></div>";
+  if( resultselectors.isEmpty() )
+  {
 
-  result += string( "<iframe id=\"gdexpandframe-" ) + getId() +
-                    "\" src=\"" + urlString.data() +
-                    "\" onmouseover=\"processIframeMouseOver('gdexpandframe-" + getId() + "');\" "
-                    "onmouseout=\"processIframeMouseOut();\" "
-                    "scrolling=\"no\" marginwidth=\"0\" marginheight=\"0\" "
-                    "frameborder=\"0\" vspace=\"0\" hspace=\"0\" "
-                    "style=\"overflow:visible; width:100%; display:none;\">"
-                    "</iframe>";
+      sptr< DataRequestInstant > dr = new DataRequestInstant( true );
 
-  dr->getData().resize( result.size() );
+      string result = "<div class=\"website_padding\"></div>";
+      result += string( "<iframe id=\"gdexpandframe-" ) + getId() +
+                        "\" src=\"" + urlString.data() +
+                        "\" onmouseover=\"processIframeMouseOver('gdexpandframe-" + getId() + "');\" "
+                        "onmouseout=\"processIframeMouseOut();\" "
+                        "scrolling=\"no\" marginwidth=\"0\" marginheight=\"0\" "
+                        "frameborder=\"0\" vspace=\"0\" hspace=\"0\" "
+                        "style=\"overflow:visible; width:100%; display:none;\">"
+                        "</iframe>";
 
-  memcpy( &( dr->getData().front() ), result.data(), result.size() );
+      dr->getData().resize( result.size() );
 
-  return dr;
+      memcpy( &( dr->getData().front() ), result.data(), result.size() );
+
+      return dr;
+  }
+  return new WebDictHttpRequest(  QUrl::fromEncoded( urlString ),
+                                   gd::toQString( str ),
+                                  resultselectors,
+                                  noresulttext,
+                                  filter,
+                                  customcss,
+                                  usePost );
 }
 
 }
@@ -128,10 +178,197 @@ vector< sptr< Dictionary::Class > > makeDictionaries( Config::WebSites const & w
     if ( ws[ x ].enabled )
       result.push_back( new WebSiteDictionary( ws[ x ].id.toUtf8().data(),
                                                ws[ x ].name.toUtf8().data(),
-                                               ws[ x ].url ) );
+                                               ws[ x ].url,
+                                               ws[ x ].resultselectors,
+                                               ws[ x ].noresulttext,
+                                               ws[ x ].filter,
+                                               ws[ x ].icon,
+                                               ws[ x ].customcss,
+                                               ws[ x ].fromlang,
+                                               ws[ x ].tolang,
+                                               ws[ x ].usepost ) );
   }
 
   return result;
+}
+
+void WebDictHttpRequest::cancel()
+{
+    if( isFinished()) return;
+    m_webpage->action( QWebPage::Stop );
+    finish();
+}
+
+WebDictHttpRequest::WebDictHttpRequest( QUrl const &url_,
+                                        QString const &word_,
+                                        QString const & resultselectors_,
+                                        QString const & noresulttext_,
+                                        QString const & filter_,
+                                        QString const & customcss_,
+                                        bool usePost_ ):
+    word( word_ ),
+    resultselectors( resultselectors_ ),
+    noresulttext( noresulttext_ ),
+    filter( filter_ ),
+    customcss( customcss_ )
+{
+    m_webpage = new QWebPage();
+    connect( m_webpage, SIGNAL(loadFinished(bool)),
+             this, SLOT( loaded(bool)) );
+    if( usePost_ )
+    {
+        QNetworkRequest req( url_ );
+        req.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded" );
+        m_webpage->currentFrame()->load( req,
+                                         QNetworkAccessManager::PostOperation,
+                                         url_.encodedQuery() );
+    }
+    else
+    {
+        m_webpage->currentFrame()->load( url_ );
+    }
+}
+
+void WebDictHttpRequest::loaded( bool ok )
+{
+    if( ok )
+    {
+
+        QWebElement doc = m_webpage->currentFrame()->documentElement();
+        if( !noresulttext.isEmpty() && doc.toOuterXml().indexOf( noresulttext ) !=-1 )
+        {
+            finish();
+            return;
+        }
+        if( !filter.isEmpty() )
+        {
+            QWebElement rel = doc.findFirst(filter);
+            while(!rel.isNull() )
+            {
+                rel.removeFromDocument();
+                rel = doc.findFirst(filter);
+            }
+        }
+        QUrl baseUrl = m_webpage->currentFrame()->baseUrl();
+        QString div;
+        QWebElement paraElement = doc.findFirst( resultselectors );
+        while (!paraElement.isNull()) {
+             //...
+            //if( paraElement.tagName().toLower() == "a" )
+          //  qDebug() <<"\n-------------\nelement:"+ paraElement.toOuterXml().toUtf8();
+            QUrl url;
+            QString attName;
+            if( paraElement.hasAttribute("href") )
+            {
+                url =QUrl::fromEncoded(paraElement.attribute("href").toUtf8());
+                attName = "href";
+            }else if( paraElement.hasAttribute("src")) {
+                url =QUrl(paraElement.attribute("src"));
+                 attName = "src";
+            }
+            if(! url.isEmpty() )
+            {
+              //  qDebug() << "url:" + url.toString();
+                if(ArticleNetworkAccessManager::RelativeUrl2Absolute( url, baseUrl ))
+                {
+                    paraElement.setAttribute(attName, QString::fromUtf8( url.toEncoded() ));
+                    //qDebug() << "real url:" + url.toString();
+                }
+            }
+            //fix inner links
+            //QWebElement child = paraElement.findFirst()
+            foreach (QWebElement child, paraElement.findAll("[href],[src]"))
+            {
+                if( child.hasAttribute( "href" ) )
+                {
+                    QUrl cUrl = QUrl::fromEncoded( child.attribute("href").toUtf8() );
+                    bool isDefineLink = false;
+                    if(child.tagName().toLower() =="a"
+                            &&( cUrl.host().isEmpty()  || cUrl.host() == baseUrl.host()) )
+                    {
+                        std::string path = cUrl.path().toUtf8().data();
+                        if( !Filetype::isNameOfSound( path )
+                                &&!Filetype::isNameOfPicture( path )
+                                &&!Filetype::isNameOfTiff( path ) )
+                            //TODO check for others file types
+                        {
+                            QString define = child.toPlainText().trimmed();
+                            if( !define.isEmpty() )
+                            {
+                                cUrl.setUrl( define );
+                                child.setAttribute("href", QString::fromUtf8( cUrl.toEncoded() ));
+                                isDefineLink = true;
+                            }
+                        }
+                    }
+                    //qDebug() << "url:" + cUrl.toString();
+                    if(!isDefineLink && ArticleNetworkAccessManager::RelativeUrl2Absolute( cUrl, baseUrl ))
+                    {
+                        child.setAttribute("href", QString::fromUtf8( cUrl.toEncoded() ));
+                       // qDebug() << "real url:" + cUrl.toString();
+                    }
+                }else
+                {
+                    QUrl cUrl = QUrl::fromEncoded( child.attribute("src").toUtf8() );
+                    //qDebug() << "url:" + url.toString();
+                    if( ArticleNetworkAccessManager::RelativeUrl2Absolute( cUrl, baseUrl ))
+                    {
+                        child.setAttribute("src", QString::fromUtf8( cUrl.toEncoded() ));
+                        //qDebug() << "real url:" + cUrl.toString();
+                    }
+                }
+
+            }
+            if(paraElement.tagName().toLower() =="body" )
+                div +=paraElement.toInnerXml();
+            else
+                div +=paraElement.toOuterXml();
+            paraElement.removeFromDocument();
+            paraElement = doc.findFirst( resultselectors );
+            //newEle.appendInside(paraElement);
+        }
+        if (!div.isEmpty())
+        {
+            QByteArray contentdata = "<div class=\"website_article\">";
+            //contentdata.append( dictid.c_str() );
+            if( !customcss.isEmpty())
+            {
+                QFileInfo fInfo(  QDir( Config::getConfigDir() ), customcss );
+                if( fInfo.isFile() )
+                {
+                    QFile cssFile( fInfo.absoluteFilePath()  );
+                    cssFile.open( QIODevice::ReadOnly );
+                    contentdata.append( "<style type=\"text/css\">" );
+                    contentdata.append( cssFile.readAll() );
+                    contentdata.append( "</style>" );
+                    cssFile.close();
+                }
+            }
+            contentdata.append( "<h3 class=\"website_term\">" );
+            contentdata.append( Html::escape( word.toUtf8().data()).c_str());
+            contentdata.append("</h3>" );
+            contentdata.append( div.toUtf8() );
+            contentdata.append( "</div>");
+            //qDebug() << contentdata;
+            Mutex::Lock _( dataMutex );
+
+            //size_t prevSize = data.size();
+
+            data.resize( contentdata.size() );
+
+            memcpy( &data.front() , contentdata.data(), contentdata.size() );
+
+            hasAnyData = true;
+        }
+        //this->isFinishedFlag = true;
+       // bool isEnd = isFinished();
+       // var i = isFinishedFlag;
+        //isFinished();
+       // qDebug() << (isFinished()?"Finished":"not finished");
+        //qDebug() << div.toUtf8();
+    }
+    finish();
+    //qDebug() << (isFinished()?"Finished":"not finished");
 }
 
 }

--- a/website.hh
+++ b/website.hh
@@ -6,6 +6,7 @@
 
 #include "dictionary.hh"
 #include "config.hh"
+#include <QWebPage>
 
 /// Support for any web sites via a templated url.
 namespace WebSite {
@@ -15,6 +16,28 @@ using std::string;
 
 vector< sptr< Dictionary::Class > > makeDictionaries( Config::WebSites const & )
     throw( std::exception );
+
+class WebDictHttpRequest: public Dictionary::DataRequest
+{
+  Q_OBJECT
+
+public:
+    WebDictHttpRequest( QUrl const &url_,
+                        QString const &word_,
+                        QString const & resultselectors_,
+                        QString const & noresulttext_,
+                        QString const & filter_,
+                        QString const & customcss_,
+                        bool usePost_ = false ) ;
+    ~WebDictHttpRequest(){ delete m_webpage;}
+    virtual void cancel();
+
+protected slots:
+  virtual void loaded( bool );
+private:
+    QWebPage * m_webpage;
+    QString word, resultselectors, noresulttext, filter, icon, customcss;
+};
 
 }
 


### PR DESCRIPTION
1/Result Selectors: If not empty, using QWebPage to load content. Result=DocumentElement.FindAll(Result Selectors)
2/Noresulttext: If Result contains NoresultTex -> no result
3/Filter: Not display element( DocumentElement.FindAll(filters).remove()
4/icon: Path to custom icon, if relative path, icon file is in config dir
5/customcss:Path to custom css file if relative path, css file is in config dir
6/fromlang: From Language code (ex:en, ja)
7/tolang: To Language Code

Ex: Google Translate (Vietnamese-Japanese)
0/url:http://translate.google.co.jp/#vi|ja|%GDWORD%
1/Result Selectors: #result_box
2/NoResulttex:
3/Filter:
4/icon: webdicts/icons/google.png
5/customcss: webdicts/css/google.css
6/fromlang: vi
7/tolang: en
result:http://www.mediafire.com/i/?lsdwd1bvmu3d7xm
