### PR TITLE
Enhanced XDXF support (second attempt)

### DIFF
--- a/article-style.css
+++ b/article-style.css
@@ -171,9 +171,13 @@ div.xdxf
     margin: 1px;
     margin-left: 15px;
 }
-.xdxf_def:before
+
+.xdxf_def:target
 {
-    /*content: "%%%"*/
+    /* this pseudoclass is used to marked out the referenced <def> that was just clicked */
+    border-color: red;
+    border-width: 1px;
+    border-style: double;
 }
 
 /* Abbreviation */
@@ -203,7 +207,7 @@ div.xdxf
 /* Grammar information */
 .xdxf_gr
 {
-    color: blue; /*orangered;*/
+    color: orangered;
     display: block;
 }
 
@@ -261,6 +265,13 @@ div.xdxf
   font-weight: bold;
   margin-top: 10px;
   margin-bottom: 10px;
+}
+
+/* The words in examples that are meaked out; they are marked out only when placed into <ex> tag */
+.xdxf_ex .xdxf_ex_markd, .xdxf_ex_old .xdxf_ex_markd
+{
+  color:black;
+  background-color:lightgray;
 }
 
 .xdxf_opt

--- a/xdxf2html.hh
+++ b/xdxf2html.hh
@@ -20,7 +20,7 @@ using std::map;
 /// Converts the given xdxf markup to an html one. This is currently used
 /// for Stardict's 'x' records.
 string convert( string const &, DICT_TYPE type = STARDICT, map < string, string > const * pAbrv = NULL,
-                Dictionary::Class *dictPtr = NULL, bool isLogicalFormat = false ); 
+                Dictionary::Class *dictPtr = NULL, bool isLogicalFormat = false, unsigned revisionNumber = 0 ); 
 
 }
 


### PR DESCRIPTION
This time, I have redone it right, according to Goldendict coding conventions. Please, pull my code into the main repo.

PS. I am extremely bad at C++, but I'm utterly eager to improve XDXF support. May I ask a guy who can code c++ to help me with a couple of questions?

The same way DICT_TYPE type (XDXF / Stardict) is passed from xdxf.cc to xdxf2html.cc convert() function, I want to pass dictionary format (logical / visual) and standard_version (all this is contain in <xdxf lang_from="pol" lang_to="rus" format="logical" standard_version="30">). Please help me improve XDXF support!

For you guys this is a matter of 2 minutes (just to pass an argument to a function), but for me it's an hours or trying to understand what I did wrong =(
