### PR TITLE
Fixed #314: Mac-specific: Do not enforce the default icon, allow customization

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -117,8 +117,6 @@ int main( int argc, char ** argv )
 
   #ifndef Q_OS_MAC
     app.setWindowIcon( QIcon( ":/icons/programicon.png" ) );
-  #else
-    app.setWindowIcon( QIcon( ":/icons/macicon.png" ) );
   #endif
 
   // Load translations for system locale


### PR DESCRIPTION
@goldendict/developers, what do you think? I tested on my MacOS instance, and it works as expected.
