### PR TITLE
Normalize the headwords stored in the index

### DIFF
--- a/btreeidx.cc
+++ b/btreeidx.cc
@@ -903,8 +903,9 @@ static uint32_t buildBtreeNode( IndexedWords::const_iterator & nextIndex,
 
 void IndexedWords::addWord( wstring const & word, uint32_t articleOffset, unsigned int maxHeadwordSize )
 {
-  wchar const * wordBegin = word.c_str();
-  string::size_type wordSize = word.size();
+  wstring normalizedWord = gd::normalize( word );
+  wchar const * wordBegin = normalizedWord.c_str();
+  string::size_type wordSize = normalizedWord.size();
 
   // Safeguard us against various bugs here. Don't attempt adding words
   // which are freakishly huge.

--- a/btreeidx.hh
+++ b/btreeidx.hh
@@ -31,7 +31,7 @@ enum
   /// This is to be bumped up each time the internal format changes.
   /// The value isn't used here by itself, it is supposed to be added
   /// to each dictionary's internal format version.
-  FormatVersion = 4
+  FormatVersion = 5
 };
 
 // These exceptions which might be thrown during the index traversal


### PR DESCRIPTION
Here's the problem:

Let's create the following dictionary:

```
#NAME   "non normalized headwords"
#INDEX_LANGUAGE "English"
#CONTENTS_LANGUAGE  "English"

cuté
  Single letter.

cuté
  Combining mark.
```

Currently, when user types "cute" in the search field, he will get TWO suggestions, since GD currently considers unicode-equivalent strings as completely different.

With the suggested patch, GoldenDict will just show a single suggestion. But that would require full re-index of all the dictionaries...
