### PR TITLE
Fixed navigating articles with keyboard and shortcuts for switching windows.

### DIFF
--- a/articleview.cc
+++ b/articleview.cc
@@ -823,7 +823,9 @@ bool ArticleView::eventFilter( QObject * obj, QEvent * ev )
       if ( keyEvent->key() == Qt::Key_Space ||
            keyEvent->key() == Qt::Key_Backspace ||
            keyEvent->key() == Qt::Key_Tab ||
-           keyEvent->key() == Qt::Key_Backtab )
+           keyEvent->key() == Qt::Key_Backtab ||
+           keyEvent->key() == Qt::Key_Return ||
+           keyEvent->key() == Qt::Key_Enter )
         return false; // Those key have other uses than to start typing
 
       QString text = keyEvent->text();

--- a/fulltextsearch.ui
+++ b/fulltextsearch.ui
@@ -233,6 +233,18 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>searchLine</tabstop>
+  <tabstop>headwordsView</tabstop>
+  <tabstop>checkBoxDistanceBetweenWords</tabstop>
+  <tabstop>distanceBetweenWords</tabstop>
+  <tabstop>searchMode</tabstop>
+  <tabstop>checkBoxArticlesPerDictionary</tabstop>
+  <tabstop>articlesPerDictionary</tabstop>
+  <tabstop>matchCase</tabstop>
+  <tabstop>OKButton</tabstop>
+  <tabstop>cancelButton</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/mainwindow.hh
+++ b/mainwindow.hh
@@ -76,6 +76,8 @@ public slots:
   void setExpandMode( bool expand );
 
 private:
+  void addGlobalAction( QAction * action, const char * slot );
+  void addGlobalActionsToDialog( QDialog * dialog );
 
   void commitData();
   bool commitDataCompleted;
@@ -108,7 +110,8 @@ private:
           closeAllTabAction, closeRestTabAction,
           switchToNextTabAction, switchToPrevTabAction,
           showDictBarNamesAction, useSmallIconsInToolbarsAction, toggleMenuBarAction,
-          switchExpandModeAction, focusHeadwordsDlgAction;
+          switchExpandModeAction, focusHeadwordsDlgAction, focusArticleViewAction,
+          focusFullTextSearchAction;
   QToolBar * navToolbar;
   MainStatusBar * mainStatusBar;
   QAction * navBack, * navForward, * navPronounce, * enableScanPopup;
@@ -417,6 +420,10 @@ private slots:
   void closeHeadwordsDialog();
 
   void focusHeadwordsDialog();
+
+  void focusArticleView();
+  
+  void focusFullTextSearch();
 
   void proxyAuthentication( const QNetworkProxy & proxy, QAuthenticator * authenticator );
 


### PR DESCRIPTION
- articleview.cc: fixed activating link with <Enter>. Before my changes it was impossible to activate current link in article window when navigating with <Tab>, <Shift+Tab>.
- fulltextsearch.ui: fixed FullTextSearchDialog tab order. Before my changes tab order in this dialog was completely messed up. Now it has the following logic: first searchLine, then headwordsView (can be  navigated with arrow keys), then other UI elements from top to bottom.
- mainwindow.hh, mainwindow.cc: fixed switching between UI elements via shortcuts. Apart from ensuring more consistent behavior of existing shortcuts and moving duplicated code in MainWindow::addGlobalAction method, added shortcuts to focus article view and full text search dialog.
