### PR TITLE
Third attempt to fix shortcuts and focus issues.

### DIFF
--- a/articleview.cc
+++ b/articleview.cc
@@ -823,7 +823,9 @@ bool ArticleView::eventFilter( QObject * obj, QEvent * ev )
       if ( keyEvent->key() == Qt::Key_Space ||
            keyEvent->key() == Qt::Key_Backspace ||
            keyEvent->key() == Qt::Key_Tab ||
-           keyEvent->key() == Qt::Key_Backtab )
+           keyEvent->key() == Qt::Key_Backtab ||
+           keyEvent->key() == Qt::Key_Return ||
+           keyEvent->key() == Qt::Key_Enter )
         return false; // Those key have other uses than to start typing
 
       QString text = keyEvent->text();

--- a/fulltextsearch.ui
+++ b/fulltextsearch.ui
@@ -233,6 +233,18 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>searchLine</tabstop>
+  <tabstop>headwordsView</tabstop>
+  <tabstop>checkBoxDistanceBetweenWords</tabstop>
+  <tabstop>distanceBetweenWords</tabstop>
+  <tabstop>searchMode</tabstop>
+  <tabstop>checkBoxArticlesPerDictionary</tabstop>
+  <tabstop>articlesPerDictionary</tabstop>
+  <tabstop>matchCase</tabstop>
+  <tabstop>OKButton</tabstop>
+  <tabstop>cancelButton</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -92,6 +92,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   toggleMenuBarAction( tr( "&Menubar" ), this ),
   switchExpandModeAction( this ),
   focusHeadwordsDlgAction( this ),
+  focusArticleViewAction( this ),
   trayIconMenu( this ),
   addTab( this ),
   cfg( cfg_ ),
@@ -337,54 +338,21 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   connect( trayIconMenu.addAction( tr( "&Quit" ) ), SIGNAL( triggered() ),
            qApp, SLOT( quit() ) );
 
-  escAction.setShortcutContext( Qt::WidgetWithChildrenShortcut );
+  addGlobalAction( &escAction, SLOT( handleEsc() ) );
   escAction.setShortcut( QKeySequence( "Esc" ) );
-  connect( &escAction, SIGNAL( triggered() ),
-           this, SLOT( handleEsc() ) );
 
-  focusTranslateLineAction.setShortcutContext( Qt::WidgetWithChildrenShortcut );
+  addGlobalAction( &focusTranslateLineAction, SLOT( focusTranslateLine() ) );
   focusTranslateLineAction.setShortcuts( QList< QKeySequence >() <<
                                          QKeySequence( "Alt+D" ) <<
                                          QKeySequence( "Ctrl+L" ) );
 
-  connect( &focusTranslateLineAction, SIGNAL( triggered() ),
-           this, SLOT( focusTranslateLine() ) );
-
-  focusHeadwordsDlgAction.setShortcutContext( Qt::WidgetWithChildrenShortcut );
+  addGlobalAction( &focusHeadwordsDlgAction, SLOT( focusHeadwordsDialog() ) );
   focusHeadwordsDlgAction.setShortcut( QKeySequence( "Ctrl+D" ) );
 
-  connect( &focusHeadwordsDlgAction, SIGNAL( triggered() ),
-           this, SLOT( focusHeadwordsDialog() ) );
+  addGlobalAction( &focusArticleViewAction, SLOT( focusArticleView() ) );
+  focusArticleViewAction.setShortcut( QKeySequence( "Ctrl+N" ) );
 
-  ui.centralWidget->addAction( &escAction );
-  ui.dictsPane->addAction( &escAction );
-  ui.searchPaneWidget->addAction( &escAction );
-  ui.historyPane->addAction( &escAction );
-  groupList->addAction( &escAction );
-  translateBox->addAction( &escAction );
-
-  ui.centralWidget->addAction( &focusTranslateLineAction );
-  ui.dictsPane->addAction( &focusTranslateLineAction );
-  ui.searchPaneWidget->addAction( &focusTranslateLineAction );
-  ui.historyPane->addAction( &focusTranslateLineAction );
-  groupList->addAction( &focusTranslateLineAction );
-
-  ui.centralWidget->addAction( &focusHeadwordsDlgAction );
-  ui.dictsPane->addAction( &focusHeadwordsDlgAction );
-  ui.searchPaneWidget->addAction( &focusHeadwordsDlgAction );
-  ui.historyPane->addAction( &focusHeadwordsDlgAction );
-  groupList->addAction( &focusHeadwordsDlgAction );
-  translateBox->addAction( &focusHeadwordsDlgAction );
-
-  connect( ui.fullTextSearchAction, SIGNAL( triggered() ),
-           this, SLOT( showFullTextSearchDialog() ) );
-
-  ui.centralWidget->addAction( ui.fullTextSearchAction );
-  ui.dictsPane->addAction( ui.fullTextSearchAction );
-  ui.searchPaneWidget->addAction( ui.fullTextSearchAction );
-  ui.historyPane->addAction( ui.fullTextSearchAction );
-  groupList->addAction( ui.fullTextSearchAction );
-  translateBox->addAction( ui.fullTextSearchAction );
+  addGlobalAction( ui.fullTextSearchAction, SLOT( showFullTextSearchDialog() ) );
 
   addTabAction.setShortcutContext( Qt::WidgetWithChildrenShortcut );
   addTabAction.setShortcut( QKeySequence( "Ctrl+T" ) );
@@ -967,6 +935,27 @@ MainWindow::~MainWindow()
   }
 
   commitData();
+}
+
+void MainWindow::addGlobalAction( QAction * action, const char * slot )
+{
+  action->setShortcutContext( Qt::WidgetWithChildrenShortcut );
+  connect( action, SIGNAL( triggered() ), this, slot );
+
+  ui.centralWidget->addAction( action );
+  ui.dictsPane->addAction( action );
+  ui.searchPaneWidget->addAction( action );
+  ui.historyPane->addAction( action );
+  groupList->addAction( action );
+  translateBox->addAction( action );
+}
+
+void MainWindow::addGlobalActionsToDialog( QDialog * dialog )
+{
+  dialog->addAction( &focusTranslateLineAction );
+  dialog->addAction( &focusHeadwordsDlgAction );
+  dialog->addAction( &focusArticleViewAction );
+  dialog->addAction( ui.fullTextSearchAction );
 }
 
 void MainWindow::commitData( QSessionManager & )
@@ -3749,6 +3738,7 @@ void MainWindow::showDictionaryHeadwords( Dictionary::Class * dict )
   if( headwordsDlg == 0 )
   {
     headwordsDlg = new DictHeadwords( this, cfg, dict );
+    addGlobalActionsToDialog( headwordsDlg );
     connect( headwordsDlg, SIGNAL( headwordSelected( QString ) ),
              this, SLOT( wordReceived( QString ) ) );
     connect( headwordsDlg, SIGNAL( closeDialog() ),
@@ -3772,7 +3762,22 @@ void MainWindow::closeHeadwordsDialog()
 void MainWindow::focusHeadwordsDialog()
 {
   if( headwordsDlg )
+  {
     headwordsDlg->activateWindow();
+    if ( ftsDlg )
+      ftsDlg->lower();
+  }
+}
+
+void MainWindow::focusArticleView()
+{
+  ArticleView * view = getCurrentArticleView();
+  if ( view )
+  {
+    if ( !isActiveWindow() )
+      activateWindow();
+    view->focus();
+  }
 }
 
 void MainWindow::editDictionary( Dictionary::Class * dict )
@@ -3988,6 +3993,7 @@ void MainWindow::showFullTextSearchDialog()
   if( !ftsDlg )
   {
     ftsDlg = new FTS::FullTextSearchDialog( this, cfg, dictionaries, groupInstances, ftsIndexing );
+    addGlobalActionsToDialog( ftsDlg );
 
     connect( ftsDlg, SIGNAL( showTranslationFor( QString, QStringList, QRegExp ) ),
              this, SLOT( showTranslationFor( QString, QStringList, QRegExp ) ) );
@@ -3995,16 +4001,20 @@ void MainWindow::showFullTextSearchDialog()
              this, SLOT( closeFullTextSearchDialog() ), Qt::QueuedConnection );
     connect( &configEvents, SIGNAL( mutedDictionariesChanged() ),
              ftsDlg, SLOT( updateDictionaries() ) );
-  }
 
-  unsigned group = groupInstances.empty() ? 0
-                                          : groupInstances[ groupList->currentIndex() ].id;
-  ftsDlg->setCurrentGroup( group );
+    unsigned group = groupInstances.empty() ? 0
+                                            : groupInstances[ groupList->currentIndex() ].id;
+    ftsDlg->setCurrentGroup( group );
+  }
 
   if( !ftsDlg ->isVisible() )
     ftsDlg->show();
   else
+  {
     ftsDlg->activateWindow();
+    if ( headwordsDlg )
+      headwordsDlg->lower();
+  }
 }
 
 void MainWindow::closeFullTextSearchDialog()

--- a/mainwindow.hh
+++ b/mainwindow.hh
@@ -76,6 +76,8 @@ public slots:
   void setExpandMode( bool expand );
 
 private:
+  void addGlobalAction( QAction * action, const char * slot );
+  void addGlobalActionsToDialog( QDialog * dialog );
 
   void commitData();
   bool commitDataCompleted;
@@ -108,7 +110,7 @@ private:
           closeAllTabAction, closeRestTabAction,
           switchToNextTabAction, switchToPrevTabAction,
           showDictBarNamesAction, useSmallIconsInToolbarsAction, toggleMenuBarAction,
-          switchExpandModeAction, focusHeadwordsDlgAction;
+          switchExpandModeAction, focusHeadwordsDlgAction, focusArticleViewAction;
   QToolBar * navToolbar;
   MainStatusBar * mainStatusBar;
   QAction * navBack, * navForward, * navPronounce, * enableScanPopup;
@@ -417,6 +419,8 @@ private slots:
   void closeHeadwordsDialog();
 
   void focusHeadwordsDialog();
+
+  void focusArticleView();
 
   void proxyAuthentication( const QNetworkProxy & proxy, QAuthenticator * authenticator );
 


### PR DESCRIPTION
There is only one change since https://github.com/goldendict/goldendict/pull/480:
cancelled setting focus to results list in `FullTextSearchDialog` after first result is found.
