### PR TITLE
Added support of hidpi resolutions (retina displays) on mac with qt4

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -83,7 +83,6 @@ int main( int argc, char ** argv )
 {
   #ifdef Q_OS_MAC
     setenv("LANG", "en_US.UTF-8", 1);
-    setenv("QT_GRAPHICSSYSTEM", "raster", 1);
   #endif
 
   // The following clause fixes a race in the MinGW runtime where throwing


### PR DESCRIPTION
Adding support for retina displays on mac os x.
Tested on Macbook pro, Mac os X 10.9 with Qt 4.8.6 - works fine.
