### PR TITLE
Fixed error about missing config.pri in Qt5

### DIFF
--- a/qtsingleapplication/common.pri
+++ b/qtsingleapplication/common.pri
@@ -1,4 +1,4 @@
-infile(config.pri, SOLUTIONS_LIBRARY, yes): CONFIG += qtsingleapplication-uselib
+exists(config.pri):infile(config.pri, SOLUTIONS_LIBRARY, yes): CONFIG += qtsingleapplication-uselib
 TEMPLATE += fakelib
 QTSINGLEAPPLICATION_LIBNAME = $$qtLibraryTarget(QtSolutions_SingleApplication-head)
 TEMPLATE -= fakelib


### PR DESCRIPTION
qmake terminated with error message:
  Cannot read ./goldendict/qtsingleapplication/config.pri: No such file or directory