### PR TITLE
Update mainwindow.cc

### DIFF
--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -2816,7 +2816,11 @@ void MainWindow::hotKeyActivated( int hk )
     toggleMainWindow();
   else
   if ( scanPopup.get() )
+#ifdef Q_OS_LINUX
+    scanPopup->translateWordFromSelection();
+#else
     scanPopup->translateWordFromClipboard();
+#endif
 }
 
 void MainWindow::prepareNewReleaseChecks()


### PR DESCRIPTION
This fix is related to this issue https://github.com/goldendict/goldendict/issues/598
Ctrl+c+c doesn't works on my Linux with KDE desktop environment.
Qt docs http://doc.qt.digia.com/qt-maemo/qclipboard.html says:
Lastly, the X11 clipboard is event driven, i.e. the clipboard will not function properly if the event loop is not running. Similarly, it is recommended that the contents of the clipboard are stored or retrieved in direct response to user-input events, e.g. mouse button or key presses and releases. You should not store or retrieve the clipboard contents in response to timer or non-user-input events.

I propose the fix above, with it goldendict ctrl+c+c works on my KDE desktop as it should.