### PR TITLE
Focus fixes

### DIFF
--- a/articleview.hh
+++ b/articleview.hh
@@ -133,6 +133,10 @@ public slots:
 
 public:
 
+  /// Returns true if the view has focus.
+  bool viewHasFocus() const
+  { return ui.definition->hasFocus(); }
+
   /// Takes the focus to the view
   void focus()
   { ui.definition->setFocus( Qt::ShortcutFocusReason ); }

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -1545,6 +1545,7 @@ ArticleView * MainWindow::createNewTab( bool switchToIt,
 void MainWindow::tabCloseRequested( int x )
 {
   QWidget * w = ui.tabWidget->widget( x );
+  const bool articleViewHadFocus = getCurrentArticleView()->viewHasFocus();
 
   mruList.removeOne(w);
 
@@ -1562,6 +1563,10 @@ void MainWindow::tabCloseRequested( int x )
   // if everything is closed, add a new tab
   if ( ui.tabWidget->count() == 0 )
     addNewTab();
+
+  // Prevent focus hijacking by dictsPane (or potentially by some other widget).
+  if ( articleViewHadFocus )
+    getCurrentArticleView()->focus();
 }
 
 void MainWindow::closeCurrentTab()
@@ -2743,7 +2748,6 @@ void MainWindow::toggleMainWindow( bool onlyShow )
     if( ftsDlg )
       ftsDlg->show();
 
-    focusTranslateLine();
 #ifdef Q_WS_X11
     Window wh = 0;
     int rev = 0;


### PR DESCRIPTION
This pull request fixes 2 focus issues:
1. [in MainWindow::toggleMainWindow] After hiding/showing the main window, the translate line would hijack the focus from whatever widget had it previously. This is not particularly useful, because the translate line focus policy is greedy enough already. On the other hand having to return focus back to the previously used widget manually can be annoying. I was most irritated by the need to give focus back to the article view, when navigating through the article with keyboard.
2. After closing the current tab, the focus would be hijacked from the article view by Results Navigation Pane. In case when the user (such as myself :)) prefers to keeps focus on the article view, this behavior causes inconvenience.

Note: I think that it is safe to assume that (getCurrentArticleView() != nullptr) in MainWindow::tabCloseRequested. I performed some testing on GNU/Linux both in master and in qt4x5 branches, and haven't experienced crashes. But I prepared a defensive-programming branch https://github.com/vedgy/goldendict/tree/focus-fixes-defensive anyway, just in case I'm mistaken. Please merge whichever branch looks better.