### PR TITLE
splash screen - Update just 5 lines in main.cc

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -30,6 +30,7 @@
 #include <QDebug>
 #include <QFile>
 #include <QString>
+#include <QSplashScreen>
 
 #include "gddebug.hh"
 
@@ -306,6 +307,10 @@ int main( int argc, char ** argv )
   QWebSecurityOrigin::addLocalScheme( "gdlookup" );
 #endif
 
+  QSplashScreen *splash=new QSplashScreen;
+  splash->setPixmap(QPixmap(":/icons/dictionary.jpg"));
+  splash->show();
+
   MainWindow m( cfg );
 
   app.addDataCommiter( m );
@@ -326,6 +331,8 @@ int main( int argc, char ** argv )
     m.wordReceived( QString::fromLocal8Bit( argv[1] ) );
 #endif
 
+  splash->finish(&m);
+  
   int r = app.exec();
 
   app.removeDataCommiter( m );


### PR DESCRIPTION
for best UI consistency, please merge these changes - a splash screen is really necessary if the number of already indexed dictionaries is quite large. without it, goldendict loads silently - disappears to the user - for a good couple of seconds before anything happens.
