### PR TITLE
goldendict.desktop file improvement suggestion

### DIFF
--- a/redist/goldendict.desktop
+++ b/redist/goldendict.desktop
@@ -5,6 +5,5 @@ Categories=Office;Dictionary;Education;Qt;
 Name=GoldenDict
 GenericName=Multiformat Dictionary
 Comment=GoldenDict
-Encoding=UTF-8
 Icon=goldendict
 Exec=goldendict

--- a/redist/goldendict.desktop
+++ b/redist/goldendict.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Terminal=false
-Categories=Office;Dictionary;Education;Qt
+Categories=Office;Dictionary;Education;Qt;
 Name=GoldenDict
 GenericName=Multiformat Dictionary
 Comment=GoldenDict


### PR DESCRIPTION
Running the "desktop-file-validate" command against the goldendict.desktop file gave the following output:

```
goldendict.desktop: error: value "Office;Dictionary;Education;Qt" for string list key "Categories" in group "Desktop Entry" does not have a semicolon (';') as trailing character
goldendict.desktop: warning: value "GoldenDict" for key "Comment" in group "Desktop Entry" looks redundant with value "GoldenDict" of key "Name"
goldendict.desktop: warning: key "Encoding" in group "Desktop Entry" is deprecated
```

The two patches change the output to:

```
goldendict.desktop: hint: value "Office;Dictionary;Education;Qt;" for key "Categories" in group "Desktop Entry" contains more than one main category; application might appear more than once in the application menu
goldendict.desktop: warning: value "GoldenDict" for key "Comment" in group "Desktop Entry" looks redundant with value "GoldenDict" of key "Name"
```
