### PR TITLE
Adjust copying rules of opencc data files for OS X

### DIFF
--- a/goldendict.pro
+++ b/goldendict.pro
@@ -79,7 +79,7 @@ win32 {
             LIBS += -L$${PWD}/winlibs/lib
         }
         !x64:QMAKE_LFLAGS += -Wl,--large-address-aware
-	
+
 	isEmpty(HUNSPELL_LIB) {
           CONFIG(gcc48) {
             LIBS += -lhunspell-1.3.2
@@ -229,14 +229,14 @@ mac {
     CONFIG += zim_support
     !CONFIG( no_chinese_conversion_support ) {
         CONFIG += chinese_conversion_support
-        CONFIG( x86_64 ) {
-            QMAKE_POST_LINK += & mkdir -p GoldenDict.app/Contents/MacOS/opencc & \
-                                 cp -R $${PWD}/opencc/x64/*.json GoldenDict.app/Contents/MacOS/opencc/ & \
-                                 cp -R $${PWD}/opencc/x64/*.ocd GoldenDict.app/Contents/MacOS/opencc/
-        } else {
+        CONFIG( x86 ) {
             QMAKE_POST_LINK += & mkdir -p GoldenDict.app/Contents/MacOS/opencc & \
                                  cp -R $${PWD}/opencc/*.json GoldenDict.app/Contents/MacOS/opencc/ & \
                                  cp -R $${PWD}/opencc/*.ocd GoldenDict.app/Contents/MacOS/opencc/
+        } else {
+            QMAKE_POST_LINK += & mkdir -p GoldenDict.app/Contents/MacOS/opencc & \
+                                 cp -R $${PWD}/opencc/x64/*.json GoldenDict.app/Contents/MacOS/opencc/ & \
+                                 cp -R $${PWD}/opencc/x64/*.ocd GoldenDict.app/Contents/MacOS/opencc/
         }
     }
 }
@@ -633,4 +633,3 @@ TS_OUT ~= s/.ts/.qm/g
 PRE_TARGETDEPS += $$TS_OUT
 
 include( qtsingleapplication/src/qtsingleapplication.pri )
-


### PR DESCRIPTION
On OS X (as most Macs run 64-bit OS X now), copy x64 data as default behavior.