### PR TITLE
Give focus to article view instead of translate line when showing main window

### DIFF
--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -2760,7 +2760,7 @@ void MainWindow::toggleMainWindow( bool onlyShow )
     if( ftsDlg )
       ftsDlg->show();
 
-    focusTranslateLine();
+    focusArticleView();
 #ifdef HAVE_X11
     Window wh = 0;
     int rev = 0;


### PR DESCRIPTION
When the article view has focus, the user can both navigate the current
article with keyboard, and quickly translate a new word by just typing it
(the focus is automatically transferred to the translate line on typing).

The only real benefit of giving focus to translate line (the previous behavior)
is to facilitate editing the current translation query,
which should be more rare than navigating the article view with keyboard.