### PR TITLE
Fix Big Endian 64 bit machines build failures. (Closes: #714)

### DIFF
--- a/ripemd.cc
+++ b/ripemd.cc
@@ -171,9 +171,16 @@ void RIPEMD128::update( const uint8_t * data, size_t len )
   memcpy( &buffer[j], &data[i], len - i );
 }
 
+#ifndef av_bswap64
+static inline uint64_t av_bswap64(uint64_t x)
+{
+  return (uint64_t)qFromLittleEndian<uint32_t>(x) << 32 | qFromLittleEndian<uint32_t>(x >> 32);
+}
+#endif
+
 void RIPEMD128::digest( uint8_t * digest )
 {
-  uint64_t finalcount = qFromLittleEndian( count << 3 );
+  uint64_t finalcount = av_bswap64( count << 3 );
   update( (const uint8_t *) "\200", 1 );
   while ( ( count & 63 ) != 56 )
     update( ( const uint8_t * ) "", 1 );


### PR DESCRIPTION
This should fix the s390x and sparc64 build failures
 Code inspired from av_bswap64 libavutil function
 Thanks Adam Conrad for the help!

build/ripemd.o: In function `unsigned long qFromLittleEndian<unsigned long>(unsigned long)':
/usr/include/qt4/QtCore/qendian.h:344: undefined reference to`unsigned long qbswap<unsigned long>(unsigned long)'
collect2: error: ld returned 1 exit status
