### PR TITLE
Add missing options from *.ifo files

### DIFF
--- a/stardict.cc
+++ b/stardict.cc
@@ -908,22 +908,35 @@ QString const& StardictDictionary::getDescription()
     Ifo ifo( ifoFile );
 
     if( !ifo.copyright.empty() )
-      dictionaryDescription += "Copyright: "
-                               + QString::fromUtf8( ifo.copyright.c_str() )
-                                 .replace( "<br>", "\n", Qt::CaseInsensitive )
-                               + "\n\n";
+    {
+      QString copyright = QString::fromUtf8( ifo.copyright.c_str() )
+                          .replace( "<br>", "\n", Qt::CaseInsensitive );
+      dictionaryDescription += QString( QObject::tr( "Copyright: %1\n\n" ) ).arg( copyright );
+    }
 
     if( !ifo.author.empty() )
-      dictionaryDescription += "Author: " + QString::fromUtf8( ifo.author.c_str() ) + "\n\n";
+    {
+      QString author = QString::fromUtf8( ifo.author.c_str() );
+      dictionaryDescription += QString( QObject::tr( "Author: %1\n\n" ) ).arg( author );
+    }
 
     if( !ifo.email.empty() )
-      dictionaryDescription += "E-mail: " + QString::fromUtf8( ifo.email.c_str() ) + "\n\n";
+    {
+      QString email = QString::fromUtf8( ifo.email.c_str() );
+      dictionaryDescription += QString( QObject::tr( "E-mail: %1\n\n" ) ).arg( email );
+    }
 
     if( !ifo.website.empty() )
-      dictionaryDescription += "Website: " + QString::fromUtf8( ifo.website.c_str() ) + "\n\n";
+    {
+      QString website = QString::fromUtf8( ifo.website.c_str() );
+      dictionaryDescription += QString( QObject::tr( "Website: %1\n\n" ) ).arg( website );
+    }
 
     if( !ifo.date.empty() )
-      dictionaryDescription += "Date: " + QString::fromUtf8( ifo.date.c_str() ) + "\n\n";
+    {
+      QString date = QString::fromUtf8( ifo.date.c_str() );
+      dictionaryDescription += QString( QObject::tr( "Date: %1\n\n" ) ).arg( date );
+    }
 
     if( !ifo.description.empty() )
     {

--- a/stardict.cc
+++ b/stardict.cc
@@ -82,7 +82,7 @@ struct Ifo
   string bookname;
   uint32_t wordcount, synwordcount, idxfilesize, idxoffsetbits;
   string sametypesequence, dicttype, description;
-  string copyright, author, email;
+  string copyright, author, email, website, date;
 
   Ifo( File::Class & );
 };
@@ -919,6 +919,12 @@ QString const& StardictDictionary::getDescription()
     if( !ifo.email.empty() )
       dictionaryDescription += "E-mail: " + QString::fromUtf8( ifo.email.c_str() ) + "\n\n";
 
+    if( !ifo.website.empty() )
+      dictionaryDescription += "Website: " + QString::fromUtf8( ifo.website.c_str() ) + "\n\n";
+
+    if( !ifo.date.empty() )
+      dictionaryDescription += "Date: " + QString::fromUtf8( ifo.date.c_str() ) + "\n\n";
+
     if( !ifo.description.empty() )
     {
       QString desc = QString::fromUtf8( ifo.description.c_str() );
@@ -1389,6 +1395,12 @@ Ifo::Ifo( File::Class & f ):
       else
       if ( char const * val = beginsWith( "email=", option ) )
         email = val;
+      else
+      if ( char const * val = beginsWith( "website=", option ) )
+        website = val;
+      else
+      if ( char const * val = beginsWith( "date=", option ) )
+        date = val;
     }
   }
   catch( File::exReadError & )


### PR DESCRIPTION
What is fixed:
* Add missing _date_ and _website_ options (ref. below)
* Make option's name translatable

[StarDict file format](https://github.com/huzheng001/stardict-3/blob/master/dict/doc/StarDictFileFormat):

> {2}. The normal dictionary ".ifo" file's format.
> The .ifo file format is described in ".ifo file format" section.
> 
> magic data: "StarDict's dict ifo file"
> version: must be "2.4.2" or "3.0.0". 
> Since "3.0.0", StarDict accepts the "idxoffsetbits" option.
>
> Available options:
> 
> bookname=      // required
> wordcount=     // required
> synwordcount=  // required if ".syn" file exists.
> idxfilesize=   // required
> idxoffsetbits= // New in 3.0.0
> author=
> email=
> **website**=
> description=	// You can use &lt;br&gt; for new line.
> **date**=
> sametypesequence= // very important.
> dicttype=