### PR TITLE
Forvo: order pronunciations by rate, high rated first

### DIFF
--- a/forvo.cc
+++ b/forvo.cc
@@ -168,8 +168,13 @@ void ForvoArticleRequest::addQuery( QNetworkAccessManager & mgr,
     key = apiKey;
 
   QUrl reqUrl = QUrl::fromEncoded(
-      QString( "http://apifree.forvo.com/key/" + key + "/format/xml/action/word-pronunciations/word/" +
-      QString::fromLatin1( QUrl::toPercentEncoding( gd::toQString( str ) ) ) + "/language/" + languageCode
+      QString( "http://apifree.forvo.com"
+               "/key/" + key +
+               "/action/word-pronunciations"
+               "/format/xml"
+               "/word/" + QLatin1String( QUrl::toPercentEncoding( gd::toQString( str ) ) ) +
+               "/language/" + languageCode +
+               "/order/rate-desc"
        ).toUtf8() );
 
 //  DPRINTF( "req: %s\n", reqUrl.toEncoded().data() );


### PR DESCRIPTION
Added `/order/rate-desc` parameter (see [Forvo API](https://api.forvo.com/documentation/word-pronunciations/)).
Example before:
![screenshot_before](https://user-images.githubusercontent.com/688044/29964958-7d15df42-8f14-11e7-9c58-a46394567c48.jpg)
Example after:
![screenshot_after](https://user-images.githubusercontent.com/688044/29964772-df4250a2-8f13-11e7-93bf-7fc834e0cf9b.jpg)
