### PR TITLE
Fix typos found by codespell; various fixes

### DIFF
--- a/article-style-st-babylon.css
+++ b/article-style-st-babylon.css
@@ -50,7 +50,7 @@ h3 {
 	vertical-align: text-top;
 }
 
-/* The 'From ' string which preceeds dictionary name in the heading */
+/* The 'From ' string which precedes dictionary name in the heading */
 .gdfromprefix
 {
 	display: none;

--- a/article-style-st-modern.css
+++ b/article-style-st-modern.css
@@ -49,7 +49,7 @@ a:hover
   display: none;
 }
 
-/* Hide the 'From ' string which preceeds dictionary name in the heading */
+/* Hide the 'From ' string which precedes dictionary name in the heading */G
 .gdfromprefix
 {
   display: none;

--- a/article-style.css
+++ b/article-style.css
@@ -39,7 +39,7 @@ pre
   /*background: #ffffdd;*/
 }
 
-/* The 'From ' string which preceeds dictionary name in the heading */
+/* The 'From ' string which precedes dictionary name in the heading */
 .gdfromprefix
 {
 }

--- a/articlewebview.hh
+++ b/articlewebview.hh
@@ -9,7 +9,7 @@
 
 class ArticleInspector;
 
-/// A thin wrapper around QWebView to accomodate to some ArticleView's needs.
+/// A thin wrapper around QWebView to accommodate to some ArticleView's needs.
 /// Currently the only added features:
 /// 1. Ability to know if the middle mouse button is pressed or not according
 ///    to the view's current state. This is used to open links in new tabs when

--- a/chinese.cc
+++ b/chinese.cc
@@ -91,14 +91,14 @@ std::vector< gd::wstring > CharacterConversionDictionary::getAlternateWritings( 
           opencc_convert_utf8_free( tmp );
         }
         else
-          gdWarning( "OpenCC: convertion failed %s\n", opencc_error() );
+          gdWarning( "OpenCC: conversion failed %s\n", opencc_error() );
       }
 #else
       output = converter->Convert( input );
 #endif
       result = Utf8::decode( output );
     } catch ( std::exception& ex ) {
-      gdWarning( "OpenCC: convertion failed %s\n", ex.what() );
+      gdWarning( "OpenCC: conversion failed %s\n", ex.what() );
     }
 
     if ( !result.empty() && result != folded )

--- a/gddebug.cc
+++ b/gddebug.cc
@@ -29,6 +29,8 @@ QTextCodec *localeCodec = 0;
   {
     QTextCodec::setCodecForLocale( localeCodec );
   }
+
+  va_end(ap);
 }
 
 void gdDebug(const char *msg, ...)
@@ -52,4 +54,6 @@ QTextCodec *localeCodec = 0;
   {
     QTextCodec::setCodecForLocale( localeCodec );
   }
+
+  va_end(ap);
 }

--- a/locale/ar_SA.ts
+++ b/locale/ar_SA.ts
@@ -3324,7 +3324,7 @@ To find &apos;*&apos;, &apos;?&apos;, &apos;[&apos;, &apos;]&apos; symbols use &
     </message>
     <message>
         <location filename="../preferences.ui" line="99"/>
-        <source>When enabled, an icon appears in the sytem tray area which can be used
+        <source>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</source>
         <translation>عند تمكينه، سيظهر رمز في صينية النظام حيث يمكن استخدامها
 لفتح النافذة الرئيسية وإجراء مهامَ أخرى.</translation>

--- a/locale/ay_WI.ts
+++ b/locale/ay_WI.ts
@@ -3527,7 +3527,7 @@ pestaña chiqan ist&apos;aratatawal.</translation>
         <translation>Machak pestañanak ist&apos;aran </translation>
     </message>
     <message>
-        <source>When enabled, an icon appears in the sytem tray area which can be used
+        <source>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</source>
         <translation>Mä icono ist&apos;arasin, mä t&apos;uqu ist&apos;ari </translation>
     </message>

--- a/locale/be_BY.ts
+++ b/locale/be_BY.ts
@@ -3367,7 +3367,7 @@ be the last ones.</source>
     </message>
     <message>
         <location filename="../preferences.ui" line="99"/>
-        <source>When enabled, an icon appears in the sytem tray area which can be used
+        <source>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</source>
         <translation>Калі ўлучана, у сыстэмным лотку зьявіцца значак, які можна
 карыстаць для выкліканьня галоўнага акна ды іншых дзеяньняў.</translation>

--- a/locale/be_BY@latin.ts
+++ b/locale/be_BY@latin.ts
@@ -3367,7 +3367,7 @@ kali tolki adna ŭkładka jość adčynienaja.</translation>
     </message>
     <message>
         <location filename="../preferences.ui" line="99"/>
-        <source>When enabled, an icon appears in the sytem tray area which can be used
+        <source>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</source>
         <translation>Kali ŭłučana, u systemnym łotku źjavicca značak, jaki možna
 karystać dla vyklikańnia hałoŭnaha akna dy inšych dziejańniaŭ.</translation>

--- a/locale/bg_BG.ts
+++ b/locale/bg_BG.ts
@@ -2749,7 +2749,7 @@ be the last ones.</source>
         <translation>Отваряне на новите подпрозорци след текущия</translation>
     </message>
     <message>
-        <source>When enabled, an icon appears in the sytem tray area which can be used
+        <source>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</source>
         <translation>Когато това е включено, в системната област за уведомяване се показва икона, чрез
 която може да се отваря главния прозорец или да се извършнат други дейности.</translation>

--- a/locale/cs_CZ.ts
+++ b/locale/cs_CZ.ts
@@ -3525,7 +3525,7 @@ kartou. Jinak jsou otevřeny jako poslední.</translation>
         <translation>Otevírat nové karty za současnou</translation>
     </message>
     <message>
-        <source>When enabled, an icon appears in the sytem tray area which can be used
+        <source>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</source>
         <translation>Pokud zapnuto, zobrazí se v systémovém panelu ikona, která pak může 
 být použita pro otevření hlavního okna a k provádění jiných úloh.</translation>

--- a/locale/de_DE.ts
+++ b/locale/de_DE.ts
@@ -3442,7 +3442,7 @@ Andernfalls werden sie ans Ende hinzugefügt.</translation>
     </message>
     <message>
         <location filename="../preferences.ui" line="99"/>
-        <source>When enabled, an icon appears in the sytem tray area which can be used
+        <source>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</source>
         <translation>Falls aktiviert, erscheint ein Symbol in der Symbolleiste, mit welchem das 
 Hauptfenster geöffnet und andere Aufgaben getätigt werden können.</translation>

--- a/locale/el_GR.ts
+++ b/locale/el_GR.ts
@@ -3501,7 +3501,7 @@ be the last ones.</source>
     </message>
     <message>
         <location filename="../preferences.ui" line="99"/>
-        <source>When enabled, an icon appears in the sytem tray area which can be used
+        <source>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</source>
         <translation>Αν ενεργοποιηθεί, θα εμφανίζεται ένα εικονίδιο στην περιοχή ειδοποιήσεων
 που θα σας παρέχει διάφορες δυνατότητες, π.χ. άνοιγμα κύριου παραθύρου.</translation>

--- a/locale/eo_EO.ts
+++ b/locale/eo_EO.ts
@@ -3321,7 +3321,7 @@ To find &apos;*&apos;, &apos;?&apos;, &apos;[&apos;, &apos;]&apos; symbols use &
     </message>
     <message>
         <location filename="../preferences.ui" line="99"/>
-        <source>When enabled, an icon appears in the sytem tray area which can be used
+        <source>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/locale/es_AR.ts
+++ b/locale/es_AR.ts
@@ -4250,7 +4250,7 @@ se agregarán al final de la lista de pestañas.</translation>
     </message>
     <message>
         <location filename="../preferences.ui" line="99"/>
-        <source>When enabled, an icon appears in the sytem tray area which can be used
+        <source>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</source>
         <translation>Con esta opción activada, un ícono aparecerá
 en la bandeja del sistema, el cual puede usarse

--- a/locale/es_BO.ts
+++ b/locale/es_BO.ts
@@ -4209,7 +4209,7 @@ abiertas al lado de la pestaña actual.</translation>
     </message>
     <message>
         <location filename="../preferences.ui" line="99"/>
-        <source>When enabled, an icon appears in the sytem tray area which can be used
+        <source>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</source>
         <translation>Cuando activado un icono aparece en la bandeja del sistema que puede ser utilizado para abrir la ventana principal y realizar otras tareas. </translation>
     </message>

--- a/locale/es_ES.ts
+++ b/locale/es_ES.ts
@@ -3411,7 +3411,7 @@ justo después de la actual. Si no, se situarán las últimas.</translation>
     </message>
     <message>
         <location filename="../preferences.ui" line="99"/>
-        <source>When enabled, an icon appears in the sytem tray area which can be used
+        <source>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</source>
         <translation>Al activar esta opción, aparece un icono en el área de la bandeja del sistema que se puede usar
 para abrir la ventana actual y realizar otras tareas.</translation>

--- a/locale/fa_IR.ts
+++ b/locale/fa_IR.ts
@@ -3326,7 +3326,7 @@ To find &apos;*&apos;, &apos;?&apos;, &apos;[&apos;, &apos;]&apos; symbols use &
     </message>
     <message>
         <location filename="../preferences.ui" line="99"/>
-        <source>When enabled, an icon appears in the sytem tray area which can be used
+        <source>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</source>
         <translation>هنگامی‌که به‌کار افتاده، یک نشانه در سینی سیستم نمایش داده می‌شود
 که می‌تواند برای باز کردن پنجره اصلی و انجام دیگر کارها به‌کار برده شود.</translation>

--- a/locale/fi_FI.ts
+++ b/locale/fi_FI.ts
@@ -3320,7 +3320,7 @@ To find &apos;*&apos;, &apos;?&apos;, &apos;[&apos;, &apos;]&apos; symbols use &
     </message>
     <message>
         <location filename="../preferences.ui" line="99"/>
-        <source>When enabled, an icon appears in the sytem tray area which can be used
+        <source>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/locale/fr_FR.ts
+++ b/locale/fr_FR.ts
@@ -3465,7 +3465,7 @@ en fin de liste.</translation>
     </message>
     <message>
         <location filename="../preferences.ui" line="99"/>
-        <source>When enabled, an icon appears in the sytem tray area which can be used
+        <source>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</source>
         <translation>Lorsque cette option est active, une icône apparaît dans la barre des tâches, pouvant être utilisée
 pour ouvrir la fenâtre principale et accomplir d&apos;autres tâches.</translation>

--- a/locale/it_IT.ts
+++ b/locale/it_IT.ts
@@ -3435,7 +3435,7 @@ a quella corrente altrimenti vengono accodate all&apos;ultima.</translation>
     </message>
     <message>
         <location filename="../preferences.ui" line="99"/>
-        <source>When enabled, an icon appears in the sytem tray area which can be used
+        <source>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</source>
         <translation>Spuntando questa casella, appare un&apos;icona sulla barra di notifica per aprire 
 la finestra principale ed effettuare altre operazioni.</translation>

--- a/locale/ja_JP.ts
+++ b/locale/ja_JP.ts
@@ -3403,7 +3403,7 @@ be the last ones.</source>
     </message>
     <message>
         <location filename="../preferences.ui" line="99"/>
-        <source>When enabled, an icon appears in the sytem tray area which can be used
+        <source>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</source>
         <translation>有効だと、メイン ウィンドウを開いたりするのに使われる
 アイコンがシステム トレイ領域に表示されます。</translation>

--- a/locale/ko_KR.ts
+++ b/locale/ko_KR.ts
@@ -3379,7 +3379,7 @@ be the last ones.</source>
     </message>
     <message>
         <location filename="../preferences.ui" line="99"/>
-        <source>When enabled, an icon appears in the sytem tray area which can be used
+        <source>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</source>
         <translation>이 항목을 선택하면 시스템트레이에 아이콘을 만들어 
 메인창을 열거나 다른 작업을 할 수 있습니다.</translation>

--- a/locale/lt_LT.ts
+++ b/locale/lt_LT.ts
@@ -3463,7 +3463,7 @@ prie paskutiniųjų.</translation>
     </message>
     <message>
         <location filename="../preferences.ui" line="99"/>
-        <source>When enabled, an icon appears in the sytem tray area which can be used
+        <source>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</source>
         <translation>Jei pasirinkta, sistemos dėkle rodomas ženkliukas, kuriuo galite
 atverti pagrindinį langą ir atlikti kitas užduotis.</translation>

--- a/locale/mk_MK.ts
+++ b/locale/mk_MK.ts
@@ -3406,7 +3406,7 @@ be the last ones.</source>
     </message>
     <message>
         <location filename="../preferences.ui" line="99"/>
-        <source>When enabled, an icon appears in the sytem tray area which can be used
+        <source>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</source>
         <translation type="unfinished">Кога е овозможено, икона се појавува во сист.палета која можеда се користи,
 да се отвори главен прозорец и да се извршат други задачи.</translation>

--- a/locale/nl_NL.ts
+++ b/locale/nl_NL.ts
@@ -3469,7 +3469,7 @@ Indien uitgeschakeld worden ze als laatste toegevoegd.</translation>
     </message>
     <message>
         <location filename="../preferences.ui" line="99"/>
-        <source>When enabled, an icon appears in the sytem tray area which can be used
+        <source>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</source>
         <translation>Indien ingeschakeld wordt een pictogram in het systeemvak weergegeven
 waarmee u het hoofdvenster kunt openen en andere taken uit kunt voeren.</translation>

--- a/locale/pl_PL.ts
+++ b/locale/pl_PL.ts
@@ -3481,7 +3481,7 @@ aktywną. W przeciwnym razie są one dodawane na końcu.</translation>
     </message>
     <message>
         <location filename="../preferences.ui" line="99"/>
-        <source>When enabled, an icon appears in the sytem tray area which can be used
+        <source>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</source>
         <translation>Włączenie tej opcji powoduje, że na pasku zadań obecna jest ikona umożliwiająca
 otwieranie okna głównego i wykonywanie innych zadań.</translation>

--- a/locale/pt_BR.ts
+++ b/locale/pt_BR.ts
@@ -3372,7 +3372,7 @@ quando apenas uma delas estiver aberta.</translation>
     </message>
     <message>
         <location filename="../preferences.ui" line="99"/>
-        <source>When enabled, an icon appears in the sytem tray area which can be used
+        <source>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</source>
         <translation>Se habilitada esta opção, o programa será exibido
 na Área de Notificação como ícone, por meio do qual

--- a/locale/qu_WI.ts
+++ b/locale/qu_WI.ts
@@ -4209,7 +4209,7 @@ abiertas al lado de la pestaña actual.</translation>
     </message>
     <message>
         <location filename="../preferences.ui" line="99"/>
-        <source>When enabled, an icon appears in the sytem tray area which can be used
+        <source>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</source>
         <translation>Cuando activado un icono aparece en la bandeja del sistema que puede ser utilizado para abrir la ventana principal y realizar otras tareas. </translation>
     </message>

--- a/locale/ru_RU.ts
+++ b/locale/ru_RU.ts
@@ -3340,7 +3340,7 @@ be the last ones.</source>
     </message>
     <message>
         <location filename="../preferences.ui" line="99"/>
-        <source>When enabled, an icon appears in the sytem tray area which can be used
+        <source>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</source>
         <translation>При включении этого параметра в системном лотке появится значок,
 который можно использовать для вызова основного окна и других

--- a/locale/sk_SK.ts
+++ b/locale/sk_SK.ts
@@ -3439,7 +3439,7 @@ Inak sú pridané za poslednú kartu.</translation>
     </message>
     <message>
         <location filename="../preferences.ui" line="99"/>
-        <source>When enabled, an icon appears in the sytem tray area which can be used
+        <source>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</source>
         <translation>Ak je povolené, zobrazí sa ikona v systémového panelu, ktorú je možné použiť na otvorenie hlavného okna a ďalšie úlohy.</translation>
     </message>

--- a/locale/sq_AL.ts
+++ b/locale/sq_AL.ts
@@ -3350,7 +3350,7 @@ asaj aktive. Përndryshe ato i shtohen më të fundit.</translation>
     </message>
     <message>
         <location filename="../preferences.ui" line="99"/>
-        <source>When enabled, an icon appears in the sytem tray area which can be used
+        <source>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</source>
         <translation>Kur e aktivizon, në shiritin e sistemit shfaqet një ikonë që mund të përdoret
 për të hapur dritaren kryesore dhe për të kryer detyra të tjera.</translation>

--- a/locale/sr_SR.ts
+++ b/locale/sr_SR.ts
@@ -3422,7 +3422,7 @@ be the last ones.</source>
     </message>
     <message>
         <location filename="../preferences.ui" line="99"/>
-        <source>When enabled, an icon appears in the sytem tray area which can be used
+        <source>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</source>
         <translation>Када је омогућено, појављује се икона у палети која се може користити,
 да отвори главни прозор и врши друге послове.</translation>

--- a/locale/sv_SE.ts
+++ b/locale/sv_SE.ts
@@ -3369,7 +3369,7 @@ de efter den sista fliken i flikfältet.</translation>
     </message>
     <message>
         <location filename="../preferences.ui" line="99"/>
-        <source>When enabled, an icon appears in the sytem tray area which can be used
+        <source>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</source>
         <translation>När detta alternativ är aktiverat visas en ikon i meddelandefältet, som kan
 användas för att öppna huvudfönstret och utföra andra uppgifter.</translation>

--- a/locale/tg_TJ.ts
+++ b/locale/tg_TJ.ts
@@ -3460,7 +3460,7 @@ be the last ones.</source>
     </message>
     <message>
         <location filename="../preferences.ui" line="99"/>
-        <source>When enabled, an icon appears in the sytem tray area which can be used
+        <source>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</source>
         <translation>Агар имконоти зерин фаъол бошад, нишонаи луғат дар панели система пайдо мешавад,
 ва шумо аз он ҷо метавонед равзанаи асосии барномаро кушоед ва амалҳои дигарро иҷро кунед.</translation>

--- a/locale/tk_TM.ts
+++ b/locale/tk_TM.ts
@@ -3430,9 +3430,9 @@ be the last ones.</translation>
     </message>
     <message>
         <location filename="../preferences.ui" line="99"/>
-        <source>When enabled, an icon appears in the sytem tray area which can be used
+        <source>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</source>
-        <translation>When enabled, an icon appears in the sytem tray area which can be used
+        <translation>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</translation>
     </message>
     <message>

--- a/locale/tr_TR.ts
+++ b/locale/tr_TR.ts
@@ -2979,7 +2979,7 @@ Aksi takdirde sekmelerin sonuna eklenecektir.</translation>
         <translation>Sistem Varsayılanı</translation>
     </message>
     <message>
-        <source>When enabled, an icon appears in the sytem tray area which can be used
+        <source>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</source>
         <translation>Etkinleştirildiğinde, ana pencereyi açın, diğer görevleri gerçekleştirmek
 ve kullanabilmek için sistem tepsisinde bir simge belirir.</translation>

--- a/locale/uk_UA.ts
+++ b/locale/uk_UA.ts
@@ -3420,7 +3420,7 @@ be the last ones.</source>
     </message>
     <message>
         <location filename="../preferences.ui" line="99"/>
-        <source>When enabled, an icon appears in the sytem tray area which can be used
+        <source>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</source>
         <translation>Коли це ввімкнено, піктограма з&apos;явиться в системному лотку, якою можна
 буде відкривати головне вікно і здійснювати інші задачі.</translation>

--- a/locale/vi_VN.ts
+++ b/locale/vi_VN.ts
@@ -2747,7 +2747,7 @@ thêm vào sau cùng.</translation>
         <translation>Mở thẻ mới ngay sau thẻ hiện tại</translation>
     </message>
     <message>
-        <source>When enabled, an icon appears in the sytem tray area which can be used
+        <source>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</source>
         <translation>Biểu tượng Từ điển Vàng sẽ hiện trên khay hệ thống dùng để mở cửa sổ chính
 và thực hiện một số tác vụ khác.</translation>

--- a/locale/zh_CN.ts
+++ b/locale/zh_CN.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0" language="zh_CN">
+<TS version="2.1" language="zh_CN">
 <context>
     <name>About</name>
     <message>
@@ -1125,7 +1125,7 @@ between classic and school orthography in cyrillic)</source>
     <message>
         <location filename="../fulltextsearch.ui" line="80"/>
         <source>Ignore words order</source>
-        <translation type="unfinished"></translation>
+        <translation>忽略单词顺序</translation>
     </message>
     <message>
         <location filename="../fulltextsearch.ui" line="101"/>
@@ -4529,7 +4529,7 @@ you must place bass.dll (http://www.un4seen.com) into GoldenDict folder.</source
     <message>
         <location filename="../scanpopup.ui" line="231"/>
         <source>Always stay on top of all other windows</source>
-        <translation type="unfinished"></translation>
+        <translation>总是位于其它窗口上方</translation>
     </message>
     <message>
         <location filename="../scanpopup.ui" line="251"/>
@@ -4706,7 +4706,7 @@ GoldenDict 尚不支持此方案。</translation>
     <message>
         <location filename="../sources.ui" line="178"/>
         <source>&amp;Change...</source>
-        <translation>变更...(&amp;C)</translation>
+        <translation>变更(&amp;C)...</translation>
     </message>
     <message>
         <location filename="../sources.ui" line="812"/>

--- a/locale/zh_CN.ts
+++ b/locale/zh_CN.ts
@@ -3636,7 +3636,7 @@ be the last ones.</source>
     </message>
     <message>
         <location filename="../preferences.ui" line="99"/>
-        <source>When enabled, an icon appears in the sytem tray area which can be used
+        <source>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</source>
         <translation>启用此选项，将会启用系统托盘图标。</translation>
     </message>

--- a/locale/zh_TW.ts
+++ b/locale/zh_TW.ts
@@ -2913,7 +2913,7 @@ be the last ones.</source>
         <translation>系統預設</translation>
     </message>
     <message>
-        <source>When enabled, an icon appears in the sytem tray area which can be used
+        <source>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</source>
         <translation>啟用此選項，將會啟用系統匣圖示。
 可用來顯示主視窗以及執行其他工作。</translation>

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -1777,7 +1777,7 @@ void MainWindow::tabSwitched( int )
 
 void MainWindow::tabMenuRequested(QPoint pos)
 {
-//  // dont show this menu for single tab
+//  // do not show this menu for single tab
 //  if ( ui.tabWidget->count() < 2 )
 //    return;
 

--- a/preferences.ui
+++ b/preferences.ui
@@ -96,7 +96,7 @@
        <item row="2" column="0">
         <widget class="QGroupBox" name="enableTrayIcon">
          <property name="toolTip">
-          <string>When enabled, an icon appears in the sytem tray area which can be used
+          <string>When enabled, an icon appears in the system tray area which can be used
 to open main window and perform other tasks.</string>
          </property>
          <property name="title">

--- a/scanpopup.hh
+++ b/scanpopup.hh
@@ -197,7 +197,7 @@ private slots:
 
   /// Called repeatedly once the popup is initially engaged and we monitor the
   /// mouse as it may move away from the window. This simulates mouse grab, in
-  /// essense, but seems more reliable. Once the mouse enters the window, the
+  /// essence, but seems more reliable. Once the mouse enters the window, the
   /// polling stops.
   void mouseGrabPoll();
 

--- a/slob.cc
+++ b/slob.cc
@@ -133,7 +133,7 @@ class SlobFile
   QString readTinyText();
   QString readText();
   QString readLargeText();
-  QString readString( unsigned lenght );
+  QString readString( unsigned length );
 
 public:
   SlobFile() :


### PR DESCRIPTION
Hello there,

FYI, I just got the uploader permission to [goldendict package in Debian](https://tracker.debian.org/pkg/goldendict). A new snapshot was packaged inside Debian recently.

Some issues were found when doing examinations on the code. This PR mainly fixes some typos as well as two missing calls to `va_end()`.