### PR TITLE
Mediawiki performance improvements

### DIFF
--- a/goldendict.pro
+++ b/goldendict.pro
@@ -461,6 +461,7 @@ SOURCES += folding.cc \
     delegate.cc \
     zim.cc \
     gddebug.cc \
+    qt4x5.cc \
     gestures.cc \
     tiff.cc \
     dictheadwords.cc \

--- a/mediawiki.cc
+++ b/mediawiki.cc
@@ -345,17 +345,25 @@ void MediaWikiArticleRequest::requestFinished( QNetworkReply * r )
             // Replace all ":" in links, remove '#' part in links to other articles
             int pos = 0;
             QRegExp regLinks( "<a\\s+href=\"/([^\"]+)\"" );
+            QString articleWithReplacements;
             for( ; ; )
             {
+              int prevPos = pos;
               pos = regLinks.indexIn( articleString, pos );
               if( pos < 0 )
+              {
+                articleWithReplacements += articleString.midRef( prevPos );
                 break;
+              }
+              articleWithReplacements += articleString.midRef( prevPos, pos - prevPos );
               QString link = regLinks.cap( 1 );
 
               if( link.indexOf( "://" ) >= 0 )
               {
                 // External link
+                prevPos = pos;
                 pos += regLinks.cap().size();
+                articleWithReplacements += articleString.midRef( prevPos, pos - prevPos );
                 continue;
               }
 
@@ -370,10 +378,10 @@ void MediaWikiArticleRequest::requestFinished( QNetworkReply * r )
                 link += QString( "?gdanchor=%1" ).arg( anchor );
               }
 
-              QString newLink = QString( "<a href=\"/%1\"" ).arg( link );
-              articleString.replace( pos, regLinks.cap().size(), newLink );
-              pos += newLink.size();
+              articleWithReplacements += QString( "<a href=\"/%1\"" ).arg( link );
+              pos += regLinks.cap().size();
             }
+            articleString = articleWithReplacements;
 
             QUrl wikiUrl( url );
             wikiUrl.setPath( "/" );

--- a/mediawiki.cc
+++ b/mediawiki.cc
@@ -374,8 +374,9 @@ void MediaWikiArticleRequest::requestFinished( QNetworkReply * r )
             wikiUrl.setPath( "/" );
   
             // Update any special index.php pages to be absolute
-            articleString.replace( QRegExp( "<a\\shref=\"(/(\\w*/)*index.php\\?)" ),
-                                   QString( "<a href=\"%1\\1" ).arg( wikiUrl.toString() ) );
+            Qt4x5::Regex::replace( articleString, "<a\\shref=\"(/(\\w*/)*index.php\\?)",
+                                   QString( "<a href=\"%1\\1" ).arg( wikiUrl.toString() ),
+                                   Qt::CaseSensitive, true );
 
             // audio tag
             QRegExp reg1( "<audio\\s.+</audio>", Qt::CaseInsensitive, QRegExp::RegExp2 );
@@ -402,7 +403,7 @@ void MediaWikiArticleRequest::requestFinished( QNetworkReply * r )
             }
 
             // audio url
-            articleString.replace( QRegExp( "<a\\s+href=\"(//upload\\.wikimedia\\.org/wikipedia/commons/[^\"'&]*\\.ogg)" ),
+            Qt4x5::Regex::replace( articleString, "<a\\s+href=\"(//upload\\.wikimedia\\.org/wikipedia/commons/[^\"'&]*\\.ogg)",
                                    QString::fromStdString( addAudioLink( string( "\"" ) + wikiUrl.scheme().toStdString() + ":\\1\"",
                                                                          this->dictPtr->getId() ) + "<a href=\"" + wikiUrl.scheme().toStdString() + ":\\1" ) );
 
@@ -412,9 +413,11 @@ void MediaWikiArticleRequest::requestFinished( QNetworkReply * r )
             articleString.replace( "src=\"/", "src=\"" + wikiUrl.toString() );
 
             // Replace the href="/foo/bar/Baz" to just href="Baz".
-            articleString.replace( QRegExp( "<a\\shref=\"/([\\w\\.]*/)*" ), "<a href=\"" );
+            Qt4x5::Regex::replace( articleString, "<a\\shref=\"/([\\w\\.]*/)*",
+                                   "<a href=\"", Qt::CaseSensitive, true );
 
             //fix audio
+            // For some reason QRegExp works faster than QRegularExpression in the replacement below.
             articleString.replace( QRegExp( "<button\\s+[^>]*(upload\\.wikimedia\\.org/wikipedia/commons/[^\"'&]*\\.ogg)[^>]*>\\s*<[^<]*</button>"),
                                             QString::fromStdString(addAudioLink( string( "\"" ) + wikiUrl.scheme().toStdString() + "://\\1\"", this->dictPtr->getId() ) +
                                             "<a href=\"" + wikiUrl.scheme().toStdString() + "://\\1\"><img src=\"qrcx://localhost/icons/playsound.png\" border=\"0\" alt=\"Play\"></a>" ) );
@@ -422,15 +425,16 @@ void MediaWikiArticleRequest::requestFinished( QNetworkReply * r )
             for( ; ; )
             {
               QString before = articleString;
-              articleString.replace( QRegExp( "<a href=\"([^/:\">#]*)_" ), "<a href=\"\\1 " );
+              Qt4x5::Regex::replace( articleString, "<a href=\"([^/:\">#]*)_", "<a href=\"\\1 " );
   
               if ( articleString == before )
                 break;
             }
 
             //fix file: url
-            articleString.replace( QRegExp("<a\\s+href=\"([^:/\"]*file%3A[^/\"]+\")", Qt::CaseInsensitive ),
-                                   QString( "<a href=\"%1/index.php?title=\\1" ).arg( url ));
+            Qt4x5::Regex::replace( articleString, "<a\\s+href=\"([^:/\"]*file%3A[^/\"]+\")",
+                                   QString( "<a href=\"%1/index.php?title=\\1" ).arg( url ),
+                                   Qt::CaseInsensitive );
 
             QByteArray articleBody = articleString.toUtf8();
   

--- a/qt4x5.cc
+++ b/qt4x5.cc
@@ -1,0 +1,26 @@
+#include "qt4x5.hh"
+
+#if IS_QT_5
+#include <QRegularExpression>
+#else
+#include <QRegExp>
+#endif
+
+QString & Qt4x5::Regex::replace( QString & text, const QString & pattern, const QString & after,
+                                 Qt::CaseSensitivity cs, bool useUnicodeProperties )
+{
+// QRegularExpression usually outperforms QRegExp, but is not available in Qt4.
+#if IS_QT_5
+  QRegularExpression::PatternOptions options = QRegularExpression::NoPatternOption;
+  if( cs == Qt::CaseInsensitive )
+    options |= QRegularExpression::CaseInsensitiveOption;
+  if( useUnicodeProperties )
+    options |= QRegularExpression::UseUnicodePropertiesOption;
+  return text.replace( QRegularExpression( pattern, options ), after );
+#else
+  // When using QRegExp, character classes such as \w, \d, etc. always
+  // match characters with the corresponding Unicode property.
+  Q_UNUSED( useUnicodeProperties )
+  return text.replace( QRegExp( pattern, cs ), after );
+#endif
+}

--- a/qt4x5.hh
+++ b/qt4x5.hh
@@ -3,6 +3,8 @@
 #ifndef QT4X5_HH
 #define QT4X5_HH
 
+#include <QtGlobal>
+
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
 # define IS_QT_5    0
 #else
@@ -160,6 +162,15 @@ typedef int size_type;
 #else
 typedef uint size_type;
 #endif
+
+}
+
+namespace Regex
+{
+
+QString & replace( QString & text, const QString & pattern, const QString & after,
+                   Qt::CaseSensitivity cs = Qt::CaseSensitive,
+                   bool useUnicodeProperties = false );
 
 }
 


### PR DESCRIPTION
This pull request speeds up MediaWiki processing of long articles by about 4 times with Qt5. Performance with Qt4 is also improved, but not nearly so much (less than twice). Qt4 toolkit is unmaintained for 2 years now, so performance in goldendict using Qt4 doesn't matter much looking forward.

Individual optimization descriptions are in the commit messages. Attached 4 performance timing documents, produced by goldendict at my performance measurements helper branch - https://github.com/vedgy/goldendict/tree/mediawiki-performance-improvements-with-measurements - on my Linux machine:
[qt5-original-timing.txt](https://github.com/goldendict/goldendict/files/1629273/qt5-original-timing.txt)
[qt5-final-timing.txt](https://github.com/goldendict/goldendict/files/1629272/qt5-final-timing.txt)
[qt4-original-timing.txt](https://github.com/goldendict/goldendict/files/1629271/qt4-original-timing.txt)
[qt4-final-timing.txt](https://github.com/goldendict/goldendict/files/1629270/qt4-final-timing.txt)

I realize that network delay when downloading a MediaWiki article often takes more time than processing the article. However I believe that these performance improvements are justified for 2 reasons:
1. CPU time is not the same as waiting for a network reply. For example, the CPU might be busy with some other job. Also wasting CPU cycles can drain a laptop battery faster.
2. The original article processing code was not scalable at all. Parts of it seem to have had about quadratic complexity. So if a much longer MediaWiki article gets created, goldendict might spend minutes processing it.

I have verified that the resulting `articleString` is the same on many articles in English/Russian Wikipedia, Wiktionary, Wookieepedia with help of another helper branch - https://github.com/vedgy/goldendict/tree/mediawiki-performance-improvements-with-regression-tests - and Bash+Meld.

Sorry, I haven't analyzed performance or checked for possible regressions on Windows/Mac, because setting up development environment on these platforms would take me some time. Besides performance measurements on virtual machines often don't reflect the reality.

The next thing to optimize in `MediaWikiArticleRequest::requestFinished()` would be the `QDomDocument` code, because about half of the overall function execution time for long MediaWiki articles is now spent on the single line of code: `dd.setContent( netReply, false, &errorStr, &errorLine, &errorColumn  )`. I think that `QXmlStreamReader` would be much faster in this code. I'm not going to work on this optimization for now because the maximum performance gain would be a 2 times improvement, and even that much is not certain.

Note that loops like this
```cpp
            QRegExp regex( "<some pattern>" );
            for( ; ; )
            {
              pos = regex.indexIn( myString, pos );
              if( pos < 0 )
                break;
              < *modify* myString >
            }
```
can be found in many places in goldendict code. When the subject string `myString` is long and there are many regular expression matches (and so many iterations), such a loop is very likely to be a performance bottleneck, because of QString detaching in each iteration.

Also note that there are functional, non-performance issues in goldendict's handling of links and images in Wookieepedia articles. I plan to fix these issues and create a separate pull request.