### PR TITLE
Show #link as a tooltip instead of empty "Definition: "

### DIFF
--- a/articleview.cc
+++ b/articleview.cc
@@ -1012,7 +1012,12 @@ void ArticleView::linkHovered ( const QString & link, const QString & , const QS
     }
 
     if( msg.isEmpty() )
-      msg = tr( "Definition: %1").arg( def );
+    {
+      if( def.isEmpty() && url.hasFragment() )
+        msg = '#' + url.fragment(); // this must be a citation, footnote or backlink
+      else
+        msg = tr( "Definition: %1").arg( def );
+    }
   }
   else
   {


### PR DESCRIPTION
Internal links in MediaWiki articles don't lead to word definitions,
so the "Definition: " prefix is not correct for them. It also does not
provide any information and is largely useless.

Perhaps the actual footnote text should be displayed in the tooltip,
but this requires distinguishing them from citations/references and
backlinks.