### PR TITLE
Add --toggle-scan-popup command line option

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -109,7 +109,7 @@ void gdMessageHandler( QtMsgType type, const char *msg_ )
 
 class GDCommandLine
 {
-  bool crashReport, logFile;
+  bool crashReport, toggleScanPopup, logFile;
   QString word, groupName, popupGroupName, errFileName;
   QVector< QString > arguments;
 public:
@@ -120,6 +120,9 @@ public:
 
   inline QString errorFileName()
   { return errFileName; }
+
+  inline bool needToggleScanPopup()
+  { return toggleScanPopup; }
 
   inline bool needSetGroup()
   { return !groupName.isEmpty(); }
@@ -145,6 +148,7 @@ public:
 
 GDCommandLine::GDCommandLine( int argc, char **argv ):
 crashReport( false ),
+toggleScanPopup( false ),
 logFile( false )
 {
   if( argc > 1 )
@@ -172,6 +176,12 @@ logFile( false )
           errFileName = arguments[ ++i ];
           crashReport = true;
         }
+        continue;
+      }
+      else
+      if( arguments[ i ].compare( "--toggle-scan-popup" ) == 0 )
+      {
+        toggleScanPopup = true;
         continue;
       }
       else
@@ -280,6 +290,12 @@ int main( int argc, char ** argv )
   if ( app.isRunning() )
   {
     bool wasMessage = false;
+
+    if( gdcl.needToggleScanPopup() )
+    {
+      app.sendMessage( "toggleScanPopup" );
+      wasMessage = true;
+    }
 
     if( gdcl.needSetGroup() )
     {
@@ -420,6 +436,9 @@ int main( int argc, char ** argv )
 
   QObject::connect( &app, SIGNAL(messageReceived(const QString&)),
     &m, SLOT(messageFromAnotherInstanceReceived(const QString&)));
+
+  if( gdcl.needToggleScanPopup() )
+    m.toggleScanPopup();
 
   if( gdcl.needSetGroup() )
     m.setGroupByName( gdcl.getGroupName(), true );

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -3654,6 +3654,11 @@ void MainWindow::messageFromAnotherInstanceReceived( QString const & message )
     toggleMainWindow( true );
     return;
   }
+  if( message == "toggleScanPopup" )
+  {
+    toggleScanPopup();
+    return;
+  }
   if( message.left( 15 ) == "translateWord: " )
   {
     if( scanPopup.get() )
@@ -4582,6 +4587,11 @@ bool MainWindow::isWordPresentedInFavorites( QString const & word, unsigned grou
     folder = igrp->favoritesFolder;
 
   return ui.favoritesPaneWidget->isHeadwordPresent( folder, word );
+}
+
+void MainWindow::toggleScanPopup()
+{
+  enableScanPopup->toggle();
 }
 
 void MainWindow::setGroupByName( QString const & name, bool main_window )

--- a/mainwindow.hh
+++ b/mainwindow.hh
@@ -74,6 +74,8 @@ public:
   QString getTranslateLineText() const
   { return translateLine->text(); }
 
+  void toggleScanPopup();
+
   /// Set group for main/popup window
   void setGroupByName( QString const & name, bool main_window );
 


### PR DESCRIPTION
This option allows to choose whether scan popup is enabled or disabled
on application start without changing the
"Start with scan popup turned on" option in Preferences.

More importantly, this option allows to assign a global keyboard
shortcut that toggles scan popup for the already running goldendict
instance in system preferences. So it implements #81 in a way.

The advantages of the command line option over a hard-coded shortcut:
  * each user can use the individually preferred key binding;
  * there is no hotkey conflict risk.

The disadvantages of the command line option are:
  * poor feature discoverability - the best I can think of is listing
    this option in the Command line switches section of Goldendict Help;
  * each user that needs the feature has to make an extra effort
    to assign a shortcut in system preferences.