### PR TITLE
Improve large buffer performance in AllowFrameReply with Qt5

### DIFF
--- a/article_netmgr.cc
+++ b/article_netmgr.cc
@@ -1,6 +1,8 @@
 /* This file is (c) 2008-2012 Konstantin Isakov <ikm@goldendict.org>
  * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
 
+#include <algorithm>
+
 #if defined( _MSC_VER ) && _MSC_VER < 1800 // VS2012 and older
 #include <stdint_msvc.h>
 #else
@@ -174,7 +176,7 @@ using std::string;
 
   qint64 AllowFrameReply::bytesAvailable() const
   {
-    return buffer.size() + QNetworkReply::bytesAvailable();
+    return qint64( buffer.size() ) + QNetworkReply::bytesAvailable();
   }
 
   void AllowFrameReply::applyError( QNetworkReply::NetworkError code )
@@ -186,15 +188,16 @@ using std::string;
   void AllowFrameReply::readDataFromBase()
   {
     QByteArray data = baseReply->readAll();
-    buffer += data;
+    buffer.insert( buffer.end(), data.cbegin(), data.cend() );
     emit readyRead();
   }
 
   qint64 AllowFrameReply::readData( char * data, qint64 maxSize )
   {
     qint64 size = qMin( maxSize, qint64( buffer.size() ) );
-    memcpy( data, buffer.data(), size );
-    buffer.remove( 0, size );
+    const std::deque< char >::iterator end = buffer.begin() + size;
+    std::copy( buffer.begin(), end, data );
+    buffer.erase( buffer.begin(), end );
     return size;
   }
 

--- a/article_netmgr.hh
+++ b/article_netmgr.hh
@@ -4,6 +4,8 @@
 #ifndef __ARTICLE_NETMGR_HH_INCLUDED__
 #define __ARTICLE_NETMGR_HH_INCLUDED__
 
+#include <deque>
+
 #include <QtNetwork>
 
 #if QT_VERSION >= 0x050200  // Qt 5.2+
@@ -59,7 +61,7 @@ class AllowFrameReply : public QNetworkReply
   Q_OBJECT
 private:
   QNetworkReply * baseReply;
-  QByteArray buffer;
+  std::deque< char > buffer;
 
   AllowFrameReply();
   AllowFrameReply( AllowFrameReply const & );


### PR DESCRIPTION
An example of a large buffer can be found in the "Michael Jordan"
article from English Wikipedia. Search for "Listen to this article"
inside this article's text or turn on the Auto-pronounce option
in Preferences. After requesting the audio playback, start scrolling
the article to notice goldendict's UI freeze.

The difference in this case is quite noticeable on my GNU/Linux machine
in Release mode: after the audio file is downloaded and before
the playback starts, the UI freezes for 18 seconds
with QByteArray buffer, while the freeze is almost absent
with std::deque buffer. The UI freezes for about a second
with std::deque buffer in Debug mode, though this shouldn't be an issue.