### PR TITLE
WIP: auto pronounce from next dictionary

### DIFF
--- a/article_maker.cc
+++ b/article_maker.cc
@@ -179,7 +179,7 @@ std::string ArticleMaker::makeHtmlHeader( QString const & word,
     result += "<link rel=\"icon\" type=\"image/png\" href=\"qrcx://localhost/flags/" + Html::escape( icon.toUtf8().data() ) + "\" />\n";
 
   result += "<script type=\"text/javascript\">"
-            "gdAudioLinks = { first: null, current: null };"
+            "gdAudioLinks = { first: null, current: null, all: [] };"
             "function gdMakeArticleActive( newId ) {"
             "if ( gdCurrentArticle != 'gdfrom-' + newId ) {"
             "el=document.getElementById( gdCurrentArticle ); el.className = el.className.replace(' gdactivearticle','');"

--- a/article_netmgr.cc
+++ b/article_netmgr.cc
@@ -436,9 +436,7 @@ sptr< Dictionary::DataRequest > ArticleNetworkAccessManager::getResource(
 
     string id = url.host().toStdString();
 
-    bool search = ( id == "search" );
-
-    if ( !search )
+    if ( !Dictionary::ResourceSearch::isSearchHost( url.host() ) )
     {
       for( unsigned x = 0; x < dictionaries.size(); ++x )
         if ( dictionaries[ x ]->getId() == id )

--- a/articleview.cc
+++ b/articleview.cc
@@ -1142,7 +1142,7 @@ void ArticleView::openLink( QUrl const & url, QUrl const & ref,
                this, SLOT( resourceDownloadFinished() ) );
     }
     else
-    if ( url.scheme() == "gdau" && url.host() == "search" )
+    if ( url.scheme() == "gdau" && Dictionary::ResourceSearch::isSearchHost( url.host() ) )
     {
       // Since searches should be limited to current group, we just do them
       // here ourselves since otherwise we'd need to pass group id to netmgr
@@ -1211,6 +1211,7 @@ void ArticleView::openLink( QUrl const & url, QUrl const & ref,
                   10000, QPixmap( ":/icons/error.png" ) );
           }
         }
+        const Dictionary::ResourceSearch::Type resourceSearchType = Dictionary::ResourceSearch::hostType( url.host() );
         for( unsigned x = 0; x < activeDicts->size(); ++x )
         {
           try
@@ -1218,8 +1219,12 @@ void ArticleView::openLink( QUrl const & url, QUrl const & ref,
             if( x == preferred )
               continue;
 
+            Dictionary::Class * const dict = (*activeDicts)[ x ].get();
+            if( dict->getResourceSearchType() != resourceSearchType )
+              continue;
+
             sptr< Dictionary::DataRequest > req =
-              (*activeDicts)[ x ]->getResource(
+              dict->getResource(
                 url.path().mid( 1 ).toUtf8().data() );
 
             resourceDownloadRequests.push_back( req );
@@ -1374,7 +1379,7 @@ ResourceToSaveHandler * ArticleView::saveResource( const QUrl & url, const QUrl 
 
   if( url.scheme() == "bres" || url.scheme() == "gico" || url.scheme() == "gdau" || url.scheme() == "gdvideo" )
   {
-    if ( url.host() == "search" )
+    if ( Dictionary::ResourceSearch::isSearchHost( url.host() ) ) /// TODO: distinguish search types!
     {
       // Since searches should be limited to current group, we just do them
       // here ourselves since otherwise we'd need to pass group id to netmgr

--- a/articleview.cc
+++ b/articleview.cc
@@ -1284,7 +1284,9 @@ void ArticleView::openLink( QUrl const & url, QUrl const & ref,
 
     if ( resourceDownloadRequests.empty() ) // No requests were queued
     {
-      QMessageBox::critical( this, "GoldenDict", tr( "The referenced resource doesn't exist." ) );
+      emit statusBarMessage(
+            tr( "WARNING: %1" ).arg( tr( "The referenced resource doesn't exist." ) ),
+            10000, QPixmap( ":/icons/error.png" ) );
       return;
     }
     else

--- a/articleview.hh
+++ b/articleview.hh
@@ -110,7 +110,7 @@ public:
   /// contexts is an optional map of context values to be passed for dictionaries.
   /// The only values to pass here are ones obtained from showDefinitionInNewTab()
   /// signal or none at all.
-  void openLink( QUrl const & url, QUrl const & referrer,
+  bool openLink( QUrl const & url, QUrl const & referrer,
                  QString const & scrollTo = QString(),
                  Contexts const & contexts = Contexts() );
 
@@ -258,7 +258,7 @@ private slots:
   void linkHovered( const QString & link, const QString & title, const QString & textContent );
   void contextMenuRequested( QPoint const & );
 
-  void resourceDownloadFinished();
+  bool resourceDownloadFinished();
 
   /// We handle pasting by attempting to define the word in clipboard.
   void pasteTriggered();

--- a/audiolink.cc
+++ b/audiolink.cc
@@ -35,5 +35,6 @@ std::string makeAudioLinkScript( std::string const & url,
 
   std::string audioLinkForDict = "gdAudioLinks['" + dictionaryId + "']";
   return "gdAudioLinks.first = gdAudioLinks.first || " + ref + ";" +
-         audioLinkForDict + " = " + audioLinkForDict + " || " + ref + ";";
+         audioLinkForDict + " = " + audioLinkForDict + " || " + ref + ";" +
+         "gdAudioLinks.all.push(" + ref + ");";
 }

--- a/dictionary.hh
+++ b/dictionary.hh
@@ -254,6 +254,24 @@ enum Feature
 Q_DECLARE_FLAGS( Features, Feature )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Features )
 
+namespace ResourceSearch {
+
+enum Type { NoSearch, LsaType, XdxfType };
+
+inline char const * lsaTypeName()
+{ return "search_lsa"; }
+
+inline char const * xdxfTypeName()
+{ return "search_xdxf"; }
+
+inline Type hostType( QString const & host )
+{ return host == lsaTypeName() ? LsaType : host == xdxfTypeName() ? XdxfType : NoSearch; }
+
+inline bool isSearchHost( QString const & host )
+{ return hostType( host ) != NoSearch; }
+
+}
+
 /// A dictionary. Can be used to query words.
 class Class
 {
@@ -293,6 +311,9 @@ public:
   /// in background.
   /// The default implementation does nothing.
   virtual void deferredInit();
+
+  virtual ResourceSearch::Type getResourceSearchType() const
+  { return ResourceSearch::NoSearch; }
 
   /// Returns the dictionary's id.
   string getId() throw()

--- a/dsl.cc
+++ b/dsl.cc
@@ -867,7 +867,7 @@ string DslDictionary::nodeToHtml( ArticleDom::Node const & node )
 
       QUrl url;
       url.setScheme( "gdau" );
-      url.setHost( QString::fromUtf8( search ? "search" : getId().c_str() ) );
+      url.setHost( QString::fromUtf8( search ? Dictionary::ResourceSearch::lsaTypeName() : getId().c_str() ) );
       url.setPath( Qt4x5::Url::ensureLeadingSlash( QString::fromUtf8( filename.c_str() ) ) );
       if( search && idxHeader.hasSoundDictionaryName )
         Qt4x5::Url::setFragment( url, QString::fromUtf8( preferredSoundDictionary.c_str() ) );

--- a/lsa.cc
+++ b/lsa.cc
@@ -164,6 +164,9 @@ public:
   LsaDictionary( string const & id, string const & indexFile,
                  vector< string > const & dictionaryFiles );
 
+  virtual Dictionary::ResourceSearch::Type getResourceSearchType() const
+  { return Dictionary::ResourceSearch::LsaType; }
+
   virtual string getName() throw();
 
   virtual map< Dictionary::Property, string > getProperties() throw()

--- a/xdxf.cc
+++ b/xdxf.cc
@@ -145,6 +145,9 @@ public:
 
   ~XdxfDictionary();
 
+  virtual Dictionary::ResourceSearch::Type getResourceSearchType() const
+  { return Dictionary::ResourceSearch::XdxfType; }
+
   virtual string getName() throw()
   { return dictionaryName; }
 

--- a/xdxf2html.cc
+++ b/xdxf2html.cc
@@ -610,7 +610,7 @@ string convert( string const & in, DICT_TYPE type, map < string, string > const 
 
             QUrl url;
             url.setScheme( "gdau" );
-            url.setHost( QString::fromUtf8( search ? "search" : dictPtr->getId().c_str() ) );
+            url.setHost( QString::fromUtf8( search ? Dictionary::ResourceSearch::xdxfTypeName() : dictPtr->getId().c_str() ) );
             url.setPath( Qt4x5::Url::ensureLeadingSlash( QString::fromUtf8( filename.c_str() ) ) );
 
             el_script.setAttribute( "type", "text/javascript" );


### PR DESCRIPTION
These changes seem to fix #970 for me.
My DSL dictionary's links still play the LSA dictionary's pronunciations.
I plan to address two TODOs:
* Remove all mentions of the no longer necessary *gdAudioLinks.first*.
* Distinguish resource search types in *ArticleView::saveResource()* in the same way as in *ArticleView::openLink()*.

I don't know if this code handles XDXF resource search type correctly because I don't have any XDXF dictionaries to test.

@Abs62, what do you think about these changes? Do you have any suggestions?