### PR TITLE
Remove unused data members from Ffmpeg::DecoderContext

### DIFF
--- a/ffmpegaudio.cc
+++ b/ffmpegaudio.cc
@@ -86,9 +86,7 @@ struct DecoderContext
     kBufferSize = 32768
   };
 
-  static QMutex deviceMutex_;
   QAtomicInt & isCancelled_;
-  QByteArray audioData_;
   QDataStream audioDataStream_;
   AVFormatContext * formatContext_;
   AVCodecContext * codecContext_;
@@ -111,8 +109,7 @@ struct DecoderContext
 
 DecoderContext::DecoderContext( QByteArray const & audioData, QAtomicInt & isCancelled ):
   isCancelled_( isCancelled ),
-  audioData_( audioData ),
-  audioDataStream_( audioData_ ),
+  audioDataStream_( audioData ),
   formatContext_( NULL ),
   codecContext_( NULL ),
   avioContext_( NULL ),


### PR DESCRIPTION
`DecoderContext::audioData_` was a redundant copy of the QByteArray
because `QDataStream::QDataStream(const QByteArray &a)` creates a QBuffer
and copies `\p a` into it via `QBuffer::setData(const QByteArray &data)`.