### PR TITLE
Overhaul audio player

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This code has been run and tested on Windows XP/Vista/7, Ubuntu Linux, Mac OS X.
 ### External Deps
 
 * Make, GCC, Git
-* Qt framework. Minimum required version is 4.6 for Windows, 4.5 for all other platforms. But Qt 4.7 or 4.8 is recommended.
+* Qt framework. Minimum required version is 4.6. But Qt 4.7 or 4.8 is recommended.
 * If you want to use Qt 5.x then use branch qt4x5
 * Qt Creator IDE is recommended for development
 * Various libraries on Linux (png, zlib, etc)

--- a/articleview.hh
+++ b/articleview.hh
@@ -10,6 +10,7 @@
 #include <QSet>
 #include <list>
 #include "article_netmgr.hh"
+#include "audioplayerinterface.hh"
 #include "instances.hh"
 #include "groupcombobox.hh"
 #include "ui_articleview.h"
@@ -23,6 +24,7 @@ class ArticleView: public QFrame
   Q_OBJECT
 
   ArticleNetworkAccessManager & articleNetMgr;
+  AudioPlayerPtr const & audioPlayer;
   std::vector< sptr< Dictionary::Class > > const & allDictionaries;
   Instances::Groups const & groups;
   bool popupView;
@@ -68,6 +70,7 @@ public:
   /// The groups aren't copied -- rather than that, the reference is kept
   ArticleView( QWidget * parent,
                ArticleNetworkAccessManager &,
+               AudioPlayerPtr const &,
                std::vector< sptr< Dictionary::Class > > const & allDictionaries,
                Instances::Groups const &,
                bool popupView,

--- a/audioplayerfactory.cc
+++ b/audioplayerfactory.cc
@@ -1,0 +1,32 @@
+/* This file is (c) 2018 Igor Kushnir <igorkuo@gmail.com>
+ * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
+
+#include "audioplayerfactory.hh"
+#include "ffmpegaudioplayer.hh"
+
+AudioPlayerFactory::AudioPlayerFactory( Config::Preferences const & p ) :
+  useInternalPlayer( p.useInternalPlayer )
+{
+  reset();
+}
+
+void AudioPlayerFactory::setPreferences( Config::Preferences const & p )
+{
+  if( p.useInternalPlayer != useInternalPlayer )
+  {
+    useInternalPlayer = p.useInternalPlayer;
+    reset();
+  }
+}
+
+void AudioPlayerFactory::reset()
+{
+#ifndef DISABLE_INTERNAL_PLAYER
+  if( useInternalPlayer )
+    playerPtr.reset( new Ffmpeg::AudioPlayer );
+  else
+#endif
+  {
+    playerPtr.reset();
+  }
+}

--- a/audioplayerfactory.cc
+++ b/audioplayerfactory.cc
@@ -1,11 +1,16 @@
 /* This file is (c) 2018 Igor Kushnir <igorkuo@gmail.com>
  * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
 
+#include <QScopedPointer>
+#include <QObject>
 #include "audioplayerfactory.hh"
 #include "ffmpegaudioplayer.hh"
+#include "externalaudioplayer.hh"
+#include "gddebug.hh"
 
 AudioPlayerFactory::AudioPlayerFactory( Config::Preferences const & p ) :
-  useInternalPlayer( p.useInternalPlayer )
+  useInternalPlayer( p.useInternalPlayer ),
+  audioPlaybackProgram( p.audioPlaybackProgram )
 {
   reset();
 }
@@ -15,7 +20,19 @@ void AudioPlayerFactory::setPreferences( Config::Preferences const & p )
   if( p.useInternalPlayer != useInternalPlayer )
   {
     useInternalPlayer = p.useInternalPlayer;
+    audioPlaybackProgram = p.audioPlaybackProgram;
     reset();
+  }
+  else
+  if( !useInternalPlayer && p.audioPlaybackProgram != audioPlaybackProgram )
+  {
+    audioPlaybackProgram = p.audioPlaybackProgram;
+    ExternalAudioPlayer * const externalPlayer =
+        qobject_cast< ExternalAudioPlayer * >( playerPtr.data() );
+    if( externalPlayer )
+      setAudioPlaybackProgram( *externalPlayer );
+    else
+      gdWarning( "External player was expected, but it does not exist.\n" );
   }
 }
 
@@ -27,6 +44,13 @@ void AudioPlayerFactory::reset()
   else
 #endif
   {
-    playerPtr.reset();
+    QScopedPointer< ExternalAudioPlayer > externalPlayer( new ExternalAudioPlayer );
+    setAudioPlaybackProgram( *externalPlayer );
+    playerPtr.reset( externalPlayer.take() );
   }
+}
+
+void AudioPlayerFactory::setAudioPlaybackProgram( ExternalAudioPlayer & externalPlayer )
+{
+  externalPlayer.setPlayerCommandLine( audioPlaybackProgram.trimmed() );
 }

--- a/audioplayerfactory.hh
+++ b/audioplayerfactory.hh
@@ -7,17 +7,25 @@
 #include "audioplayerinterface.hh"
 #include "config.hh"
 
+class ExternalAudioPlayer;
+
 class AudioPlayerFactory
 {
   Q_DISABLE_COPY( AudioPlayerFactory )
 public:
   explicit AudioPlayerFactory( Config::Preferences const & );
   void setPreferences( Config::Preferences const & );
+  /// The returned reference to a smart pointer is valid as long as this object
+  /// exists. The pointer to the owned AudioPlayerInterface may change after the
+  /// call to setPreferences(), but it is guaranteed to never be null.
   AudioPlayerPtr const & player() const { return playerPtr; }
 
 private:
   void reset();
+  void setAudioPlaybackProgram( ExternalAudioPlayer & externalPlayer );
+
   bool useInternalPlayer;
+  QString audioPlaybackProgram;
   AudioPlayerPtr playerPtr;
 };
 

--- a/audioplayerfactory.hh
+++ b/audioplayerfactory.hh
@@ -1,0 +1,24 @@
+/* This file is (c) 2018 Igor Kushnir <igorkuo@gmail.com>
+ * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
+
+#ifndef AUDIOPLAYERFACTORY_HH_INCLUDED
+#define AUDIOPLAYERFACTORY_HH_INCLUDED
+
+#include "audioplayerinterface.hh"
+#include "config.hh"
+
+class AudioPlayerFactory
+{
+  Q_DISABLE_COPY( AudioPlayerFactory )
+public:
+  explicit AudioPlayerFactory( Config::Preferences const & );
+  void setPreferences( Config::Preferences const & );
+  AudioPlayerPtr const & player() const { return playerPtr; }
+
+private:
+  void reset();
+  bool useInternalPlayer;
+  AudioPlayerPtr playerPtr;
+};
+
+#endif // AUDIOPLAYERFACTORY_HH_INCLUDED

--- a/audioplayerinterface.hh
+++ b/audioplayerinterface.hh
@@ -12,10 +12,16 @@ class AudioPlayerInterface : public QObject
 {
   Q_OBJECT
 public:
-  virtual void play( const char * data, int size ) = 0;
+  /// Stops current playback if any, copies the audio buffer at [data, data + size),
+  /// then plays this buffer. It is safe to invalidate \p data after this function call.
+  /// Returns an error message in case of immediate failure; an empty string
+  /// in case of success.
+  virtual QString play( const char * data, int size ) = 0;
+  /// Stops current playback if any.
   virtual void stop() = 0;
 
 signals:
+  /// Notifies of asynchronous errors.
   void error( QString message );
 };
 

--- a/audioplayerinterface.hh
+++ b/audioplayerinterface.hh
@@ -1,0 +1,24 @@
+/* This file is (c) 2018 Igor Kushnir <igorkuo@gmail.com>
+ * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
+
+#ifndef AUDIOPLAYERINTERFACE_HH_INCLUDED
+#define AUDIOPLAYERINTERFACE_HH_INCLUDED
+
+#include <QScopedPointer>
+#include <QString>
+#include <QObject>
+
+class AudioPlayerInterface : public QObject
+{
+  Q_OBJECT
+public:
+  virtual void play( const char * data, int size ) = 0;
+  virtual void stop() = 0;
+
+signals:
+  void error( QString message );
+};
+
+typedef QScopedPointer< AudioPlayerInterface > AudioPlayerPtr;
+
+#endif // AUDIOPLAYERINTERFACE_HH_INCLUDED

--- a/externalaudioplayer.cc
+++ b/externalaudioplayer.cc
@@ -1,0 +1,99 @@
+/* This file is (c) 2018 Igor Kushnir <igorkuo@gmail.com>
+ * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
+
+#include "externalaudioplayer.hh"
+#include "externalviewer.hh"
+
+ExternalAudioPlayer::ExternalAudioPlayer() : exitingViewer( 0 )
+{
+}
+
+ExternalAudioPlayer::~ExternalAudioPlayer()
+{
+  // Destroy viewers immediately to prevent memory and temporary file leaks
+  // at application exit.
+
+  // Set viewer to null first and foremost to make sure that onViewerDestroyed()
+  // doesn't attempt to start viewer or mess the smart pointer up.
+  stopAndDestroySynchronously( viewer.take() );
+
+  stopAndDestroySynchronously( exitingViewer );
+}
+
+void ExternalAudioPlayer::setPlayerCommandLine( QString const & playerCommandLine_ )
+{
+  playerCommandLine = playerCommandLine_;
+}
+
+QString ExternalAudioPlayer::play( const char * data, int size )
+{
+  stop();
+
+  Q_ASSERT( !viewer && "viewer must be null at this point for exception safety." );
+  try
+  {
+    // Our destructor properly destroys viewers we remember about.
+    // In the unlikely case that we call viewer.reset() during the application
+    // exit, ~QObject() prevents leaks as this class is a parent of all viewers.
+    viewer.reset( new ExternalViewer( data, size, "wav", playerCommandLine, this ) );
+  }
+  catch( const ExternalViewer::Ex & e )
+  {
+    return e.what();
+  }
+
+  if( exitingViewer )
+    return QString(); // Will start later.
+  return startViewer();
+}
+
+void ExternalAudioPlayer::stop()
+{
+  if( !exitingViewer && viewer && !viewer->stop() )
+  {
+    // Give the previous viewer a chance to stop before starting a new one.
+    // This prevents overlapping audio and possible conflicts between
+    // external program instances.
+    // Graceful stopping is better than calling viewer.reset() because:
+    //   1) the process gets a chance to clean up and save its state;
+    //   2) there is no event loop blocking and consequently no (short) UI freeze
+    //      while synchronously waiting for the external process to exit.
+    exitingViewer = viewer.take();
+  }
+  else // viewer is either not started or already stopped -> simply destroy it.
+    viewer.reset();
+}
+
+void ExternalAudioPlayer::onViewerDestroyed( QObject * destroyedViewer )
+{
+  if( exitingViewer == destroyedViewer )
+  {
+    exitingViewer = 0;
+    if( viewer )
+    {
+      QString errorMessage = startViewer();
+      if( !errorMessage.isEmpty() )
+        emit error( errorMessage );
+    }
+  }
+  else
+  if( viewer.data() == destroyedViewer )
+    viewer.take(); // viewer finished and died -> release ownership.
+}
+
+QString ExternalAudioPlayer::startViewer()
+{
+  Q_ASSERT( !exitingViewer && viewer );
+  connect( viewer.data(), SIGNAL( destroyed( QObject * ) ),
+           this, SLOT( onViewerDestroyed( QObject * ) ) );
+  try
+  {
+    viewer->start();
+  }
+  catch( const ExternalViewer::Ex & e )
+  {
+    viewer.reset();
+    return e.what();
+  }
+  return QString();
+}

--- a/externalaudioplayer.hh
+++ b/externalaudioplayer.hh
@@ -1,0 +1,44 @@
+/* This file is (c) 2018 Igor Kushnir <igorkuo@gmail.com>
+ * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
+
+#ifndef EXTERNALAUDIOPLAYER_HH_INCLUDED
+#define EXTERNALAUDIOPLAYER_HH_INCLUDED
+
+#include <QScopedPointer>
+#include <QString>
+#include "audioplayerinterface.hh"
+
+class ExternalViewer;
+
+class ExternalAudioPlayer : public AudioPlayerInterface
+{
+  Q_OBJECT
+public:
+  ExternalAudioPlayer();
+  ~ExternalAudioPlayer();
+  /// \param playerCommandLine_ Will be used in future play() calls.
+  void setPlayerCommandLine( QString const & playerCommandLine_ );
+
+  virtual QString play( const char * data, int size );
+  virtual void stop();
+
+private slots:
+  void onViewerDestroyed( QObject * destroyedViewer );
+
+private:
+  QString startViewer();
+
+  QString playerCommandLine;
+  ExternalViewer * exitingViewer; ///< If not null: points to the previous viewer,
+                                  ///< the current viewer (if any) is not started yet
+                                  ///< and waits for exitingViewer to be destroyed first.
+
+  struct ScopedPointerDeleteLater
+  {
+    static void cleanup( QObject * p ) { if( p ) p->deleteLater(); }
+  };
+  // deleteLater() is safer because viewer actively participates in the QEventLoop.
+  QScopedPointer< ExternalViewer, ScopedPointerDeleteLater > viewer;
+};
+
+#endif // EXTERNALAUDIOPLAYER_HH_INCLUDED

--- a/externalviewer.hh
+++ b/externalviewer.hh
@@ -7,7 +7,6 @@
 #include <QObject>
 #include <QTemporaryFile>
 #include <QProcess>
-#include <vector>
 #include "ex.hh"
 
 /// An external viewer, opens resources in other programs
@@ -26,14 +25,26 @@ public:
   DEF_EX( exCantCreateTempFile, "Couldn't create temporary file.", Ex )
   DEF_EX_STR( exCantRunViewer, "Couldn't run external viewer:", Ex )
 
-  ExternalViewer( QObject * parent, std::vector< char > const & data,
-                  QString const & extension, QString const & viewerCmdLine )
+  ExternalViewer( const char * data, int size,
+                  QString const & extension, QString const & viewerCmdLine,
+                  QObject * parent = 0 )
     throw( exCantCreateTempFile );
 
   // Once this is called, the object will be deleted when it's done, even if
   // the function throws.
   void start() throw( exCantRunViewer );
+
+  /// If the external process is running, requests its termination and returns
+  /// false - expect the QObject::destroyed() signal to be emitted soon.
+  /// If the external process is not running, returns true, the object
+  /// destruction is not necessarily scheduled in this case.
+  bool stop();
+  /// Kills the process if it is running and waits for it to finish.
+  void stopSynchronously();
 };
 
-#endif
+/// Call this function instead of simply deleting viewer to prevent the
+/// "QProcess: Destroyed while process X is still running." warning in log.
+void stopAndDestroySynchronously( ExternalViewer * viewer );
 
+#endif

--- a/ffmpegaudio.cc
+++ b/ffmpegaudio.cc
@@ -43,25 +43,25 @@ static inline QString avErrorString( int errnum )
   return QString::fromLatin1( buf );
 }
 
-AudioPlayer & AudioPlayer::instance()
+AudioService & AudioService::instance()
 {
-  static AudioPlayer a;
+  static AudioService a;
   return a;
 }
 
-AudioPlayer::AudioPlayer()
+AudioService::AudioService()
 {
   av_register_all();
   ao_initialize();
 }
 
-AudioPlayer::~AudioPlayer()
+AudioService::~AudioService()
 {
   emit cancelPlaying( true );
   ao_shutdown();
 }
 
-void AudioPlayer::playMemory( const char * ptr, int size )
+void AudioService::playMemory( const char * ptr, int size )
 {
   emit cancelPlaying( false );
   QByteArray audioData( ptr, size );
@@ -74,7 +74,7 @@ void AudioPlayer::playMemory( const char * ptr, int size )
   thread->start();
 }
 
-void AudioPlayer::stop()
+void AudioService::stop()
 {
   emit cancelPlaying( false );
 }

--- a/ffmpegaudio.cc
+++ b/ffmpegaudio.cc
@@ -61,10 +61,10 @@ AudioPlayer::~AudioPlayer()
   ao_shutdown();
 }
 
-void AudioPlayer::playMemory( const void * ptr, int size )
+void AudioPlayer::playMemory( const char * ptr, int size )
 {
   emit cancelPlaying( false );
-  QByteArray audioData( ( char * )ptr, size );
+  QByteArray audioData( ptr, size );
   DecoderThread * thread = new DecoderThread( audioData, this );
 
   connect( thread, SIGNAL( error( QString ) ), this, SIGNAL( error( QString ) ) );

--- a/ffmpegaudio.hh
+++ b/ffmpegaudio.hh
@@ -18,7 +18,7 @@ class AudioPlayer : public QObject
 
 public:
   static AudioPlayer & instance();
-  void playMemory( const void * ptr, int size );
+  void playMemory( const char * ptr, int size );
   void stop();
 
 signals:

--- a/ffmpegaudio.hh
+++ b/ffmpegaudio.hh
@@ -12,12 +12,12 @@
 namespace Ffmpeg
 {
 
-class AudioPlayer : public QObject
+class AudioService : public QObject
 {
   Q_OBJECT
 
 public:
-  static AudioPlayer & instance();
+  static AudioService & instance();
   void playMemory( const char * ptr, int size );
   void stop();
 
@@ -26,10 +26,8 @@ signals:
   void error( QString const & message );
 
 private:
-  AudioPlayer();
-  ~AudioPlayer();
-  AudioPlayer( AudioPlayer const & );
-  AudioPlayer & operator=( AudioPlayer const & );
+  AudioService();
+  ~AudioService();
 };
 
 class DecoderThread: public QThread

--- a/ffmpegaudioplayer.hh
+++ b/ffmpegaudioplayer.hh
@@ -1,0 +1,40 @@
+/* This file is (c) 2018 Igor Kushnir <igorkuo@gmail.com>
+ * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
+
+#ifndef FFMPEGAUDIOPLAYER_HH_INCLUDED
+#define FFMPEGAUDIOPLAYER_HH_INCLUDED
+
+#include "audioplayerinterface.hh"
+#include "ffmpegaudio.hh"
+
+#ifndef DISABLE_INTERNAL_PLAYER
+
+namespace Ffmpeg
+{
+
+class AudioPlayer : public AudioPlayerInterface
+{
+  Q_OBJECT
+public:
+  AudioPlayer()
+  {
+    connect( &AudioService::instance(), SIGNAL( error( QString ) ),
+             this, SIGNAL( error( QString ) ) );
+  }
+
+  virtual void play( const char * data, int size )
+  {
+    AudioService::instance().playMemory( data, size );
+  }
+
+  virtual void stop()
+  {
+    AudioService::instance().stop();
+  }
+};
+
+}
+
+#endif // DISABLE_INTERNAL_PLAYER
+
+#endif // FFMPEGAUDIOPLAYER_HH_INCLUDED

--- a/ffmpegaudioplayer.hh
+++ b/ffmpegaudioplayer.hh
@@ -22,9 +22,10 @@ public:
              this, SIGNAL( error( QString ) ) );
   }
 
-  virtual void play( const char * data, int size )
+  virtual QString play( const char * data, int size )
   {
     AudioService::instance().playMemory( data, size );
+    return QString();
   }
 
   virtual void stop()

--- a/goldendict.pro
+++ b/goldendict.pro
@@ -267,6 +267,7 @@ HEADERS += folding.hh \
     audioplayerinterface.hh \
     audioplayerfactory.hh \
     ffmpegaudioplayer.hh \
+    externalaudioplayer.hh \
     externalviewer.hh \
     wordfinder.hh \
     groupcombobox.hh \
@@ -398,6 +399,7 @@ SOURCES += folding.cc \
     scanpopup.cc \
     articleview.cc \
     audioplayerfactory.cc \
+    externalaudioplayer.cc \
     externalviewer.cc \
     wordfinder.cc \
     groupcombobox.cc \

--- a/goldendict.pro
+++ b/goldendict.pro
@@ -264,6 +264,9 @@ HEADERS += folding.hh \
     article_maker.hh \
     scanpopup.hh \
     articleview.hh \
+    audioplayerinterface.hh \
+    audioplayerfactory.hh \
+    ffmpegaudioplayer.hh \
     externalviewer.hh \
     wordfinder.hh \
     groupcombobox.hh \
@@ -394,6 +397,7 @@ SOURCES += folding.cc \
     article_maker.cc \
     scanpopup.cc \
     articleview.cc \
+    audioplayerfactory.cc \
     externalviewer.cc \
     wordfinder.cc \
     groupcombobox.cc \

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -118,6 +118,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   articleNetMgr( this, dictionaries, articleMaker,
                  cfg.preferences.disallowContentFromOtherSites, cfg.preferences.hideGoldenDictHeader ),
   dictNetMgr( this ),
+  audioPlayerFactory( cfg.preferences ),
   wordFinder( this ),
   newReleaseCheckTimer( this ),
   latestReleaseReply( 0 ),
@@ -1373,8 +1374,8 @@ void MainWindow::makeScanPopup()
        !cfg.preferences.enableClipboardHotkey )
     return;
 
-  scanPopup = new ScanPopup( 0, cfg, articleNetMgr, dictionaries, groupInstances,
-                             history );
+  scanPopup = new ScanPopup( 0, cfg, articleNetMgr, audioPlayerFactory.player(),
+                             dictionaries, groupInstances, history );
 
   scanPopup->setStyleSheet( styleSheet() );
 
@@ -1530,8 +1531,8 @@ void MainWindow::addNewTab()
 ArticleView * MainWindow::createNewTab( bool switchToIt,
                                         QString const & name )
 {
-  ArticleView * view = new ArticleView( this, articleNetMgr, dictionaries,
-                                        groupInstances, false, cfg,
+  ArticleView * view = new ArticleView( this, articleNetMgr, audioPlayerFactory.player(),
+                                        dictionaries, groupInstances, false, cfg,
                                         *ui.searchInPageAction,
                                         dictionaryBar.toggleViewAction(),
                                         groupList );
@@ -2086,6 +2087,8 @@ void MainWindow::editPreferences()
       ui.favoritesPaneWidget->setSaveInterval( p.favoritesStoreInterval );
 
     cfg.preferences = p;
+
+    audioPlayerFactory.setPreferences( cfg.preferences );
 
     beforeScanPopupSeparator->setVisible( cfg.preferences.enableScanPopup );
     enableScanPopup->setVisible( cfg.preferences.enableScanPopup );

--- a/mainwindow.hh
+++ b/mainwindow.hh
@@ -15,6 +15,7 @@
 #include "config.hh"
 #include "dictionary.hh"
 #include "article_netmgr.hh"
+#include "audioplayerfactory.hh"
 #include "instances.hh"
 #include "article_maker.hh"
 #include "scanpopup.hh"
@@ -151,6 +152,7 @@ private:
   QNetworkAccessManager dictNetMgr; // We give dictionaries a separate manager,
                                     // since their requests can be destroyed
                                     // in a separate thread
+  AudioPlayerFactory audioPlayerFactory;
 
   WordList * wordList;
   QLineEdit * translateLine;

--- a/scanpopup.cc
+++ b/scanpopup.cc
@@ -36,6 +36,7 @@ Qt::Popup
 ScanPopup::ScanPopup( QWidget * parent,
                       Config::Class & cfg_,
                       ArticleNetworkAccessManager & articleNetMgr,
+                      AudioPlayerPtr const & audioPlayer_,
                       std::vector< sptr< Dictionary::Class > > const & allDictionaries_,
                       Instances::Groups const & groups_,
                       History & history_ ):
@@ -72,8 +73,8 @@ ScanPopup::ScanPopup( QWidget * parent,
 
   ui.queryError->hide();
 
-  definition = new ArticleView( ui.outerFrame, articleNetMgr, allDictionaries,
-                                groups, true, cfg,
+  definition = new ArticleView( ui.outerFrame, articleNetMgr, audioPlayer_,
+                                allDictionaries, groups, true, cfg,
                                 openSearchAction,
                                 dictionaryBar.toggleViewAction()
                                 );

--- a/scanpopup.hh
+++ b/scanpopup.hh
@@ -30,6 +30,7 @@ public:
   ScanPopup( QWidget * parent,
              Config::Class & cfg,
              ArticleNetworkAccessManager &,
+             AudioPlayerPtr const &,
              std::vector< sptr< Dictionary::Class > > const & allDictionaries,
              Instances::Groups const &,
              History & );


### PR DESCRIPTION
* make adding new audio player implementations easy;
* run a single external audio player process at a time;
* external and internal audio players work similarly now: fixes #950;
* increase minimum supported Qt version from 4.5 to 4.6 in README in order to use [QScopedPointer](https://doc.qt.io/qt-5/qscopedpointer.html) introduced in Qt 4.6;
* the old external player behavior (overlapping audio from multiple processes) can be easily implemented in case someone needs it: a simple class derived from `AudioPlayerInterface` with empty `stop()` function definition plus a checkbox in Preferences.
 
    
    