### PR TITLE
Add Qt Multimedia audio player back end (Qt5 only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This code has been run and tested on Windows XP/Vista/7, Ubuntu Linux, Mac OS X.
          qtdeclarative5-dev libqtwebkit-dev libxtst-dev liblzo2-dev libbz2-dev \
          libao-dev libavutil-dev libavformat-dev libtiff5-dev libeb16-dev \
          libqt5webkit5-dev libqt5svg5-dev libqt5x11extras5-dev qttools5-dev \
-         qttools5-dev-tools
+         qttools5-dev-tools qtmultimedia5-dev libqt5multimedia5-plugins
 
 ## How to build
 
@@ -82,16 +82,21 @@ If you have problem building with libeb-dev package, you can pass
 
     qmake "CONFIG+=no_epwing_support"
 
-### Building without internal audio player
+### Building without internal audio players
 
 If you have problem building with FFmpeg/libao (for example, Ubuntu older than 12.04), you can pass
-`"DISABLE_INTERNAL_PLAYER=1"` to `qmake` in order to disable internal audio player completely:
+`"CONFIG+=no_ffmpeg_player"` to `qmake` in order to disable FFmpeg+libao internal audio player back end:
 
-    qmake "DISABLE_INTERNAL_PLAYER=1"
+    qmake "CONFIG+=no_ffmpeg_player"
+
+If you have problem building with Qt5 Multimedia or experience GStreamer run-time errors (for example, Ubuntu 14.04), you can pass
+`"CONFIG+=no_qtmultimedia_player"` to `qmake` in order to disable Qt Multimedia internal audio player back end:
+
+    qmake "CONFIG+=no_qtmultimedia_player"
 
 <b>NB:</b> All additional settings for `qmake` that you need must be combined in one `qmake` launch, for example:
 
-    qmake "CONFIG+=zim_support" "CONFIG+=no_extra_tiff_handler" "DISABLE_INTERNAL_PLAYER=1"
+    qmake "CONFIG+=zim_support" "CONFIG+=no_extra_tiff_handler" "CONFIG+=no_ffmpeg_player"
 
 
 Then, invoke `make clean` before `make` because the setting change:

--- a/audioplayerfactory.hh
+++ b/audioplayerfactory.hh
@@ -25,6 +25,7 @@ private:
   void setAudioPlaybackProgram( ExternalAudioPlayer & externalPlayer );
 
   bool useInternalPlayer;
+  Config::InternalPlayerBackend internalPlayerBackend;
   QString audioPlaybackProgram;
   AudioPlayerPtr playerPtr;
 };

--- a/config.cc
+++ b/config.cc
@@ -115,10 +115,8 @@ Preferences::Preferences():
   pronounceOnLoadMain( false ),
   pronounceOnLoadPopup( false ),
 #ifndef DISABLE_INTERNAL_PLAYER
-  useExternalPlayer( false ),
   useInternalPlayer( true ),
 #else
-  useExternalPlayer( true ),
   useInternalPlayer( false ),
 #endif
   checkForNewReleases( true ),
@@ -771,15 +769,11 @@ Class load() throw( exError )
     c.preferences.pronounceOnLoadMain = ( preferences.namedItem( "pronounceOnLoadMain" ).toElement().text() == "1" );
     c.preferences.pronounceOnLoadPopup = ( preferences.namedItem( "pronounceOnLoadPopup" ).toElement().text() == "1" );
 
-    if ( !preferences.namedItem( "useExternalPlayer" ).isNull() )
-      c.preferences.useExternalPlayer = ( preferences.namedItem( "useExternalPlayer" ).toElement().text() == "1" );
-
 #ifndef DISABLE_INTERNAL_PLAYER
     if ( !preferences.namedItem( "useInternalPlayer" ).isNull() )
       c.preferences.useInternalPlayer = ( preferences.namedItem( "useInternalPlayer" ).toElement().text() == "1" );
 #else
     c.preferences.useInternalPlayer = false;
-    c.preferences.useExternalPlayer = true;
 #endif
 
     if ( !preferences.namedItem( "audioPlaybackProgram" ).isNull() )
@@ -1660,10 +1654,6 @@ void save( Class const & c ) throw( exError )
 
     opt = dd.createElement( "pronounceOnLoadPopup" );
     opt.appendChild( dd.createTextNode( c.preferences.pronounceOnLoadPopup ? "1" : "0" ) );
-    preferences.appendChild( opt );
-
-    opt = dd.createElement( "useExternalPlayer" );
-    opt.appendChild( dd.createTextNode( c.preferences.useExternalPlayer ? "1" : "0" ) );
     preferences.appendChild( opt );
 
     opt = dd.createElement( "useInternalPlayer" );

--- a/config.hh
+++ b/config.hh
@@ -223,7 +223,6 @@ struct Preferences
   // Whether the word should be pronounced on page load, in main window/popup
   bool pronounceOnLoadMain, pronounceOnLoadPopup;
   QString audioPlaybackProgram;
-  bool useExternalPlayer;
   bool useInternalPlayer;
 
   ProxyServer proxyServer;

--- a/config.hh
+++ b/config.hh
@@ -177,6 +177,52 @@ struct FullTextSearch
   {}
 };
 
+/// This class encapsulates supported backend preprocessor logic,
+/// discourages duplicating backend names in code, which is error-prone.
+class InternalPlayerBackend
+{
+public:
+  /// Returns true if at least one backend is available.
+  static bool anyAvailable();
+  /// Returns the default backend or null backend if none is available.
+  static InternalPlayerBackend defaultBackend();
+  /// Returns the name list of supported backends.
+  static QStringList nameList();
+
+  /// Returns true if built with FFmpeg player support and the name matches.
+  bool isFfmpeg() const;
+  /// Returns true if built with Qt Multimedia player support and the name matches.
+  bool isQtmultimedia() const;
+
+  QString const & uiName() const
+  { return name; }
+
+  void setUiName( QString const & name_ )
+  { name = name_; }
+
+  bool operator == ( InternalPlayerBackend const & other ) const
+  { return name == other.name; }
+
+  bool operator != ( InternalPlayerBackend const & other ) const
+  { return ! operator == ( other ); }
+
+private:
+#ifdef MAKE_FFMPEG_PLAYER
+  static InternalPlayerBackend ffmpeg()
+  { return InternalPlayerBackend( "FFmpeg+libao" ); }
+#endif
+
+#ifdef MAKE_QTMULTIMEDIA_PLAYER
+  static InternalPlayerBackend qtmultimedia()
+  { return InternalPlayerBackend( "Qt Multimedia" ); }
+#endif
+
+  explicit InternalPlayerBackend( QString const & name_ ) : name( name_ )
+  {}
+
+  QString name;
+};
+
 /// Various user preferences
 struct Preferences
 {
@@ -222,8 +268,9 @@ struct Preferences
 
   // Whether the word should be pronounced on page load, in main window/popup
   bool pronounceOnLoadMain, pronounceOnLoadPopup;
-  QString audioPlaybackProgram;
   bool useInternalPlayer;
+  InternalPlayerBackend internalPlayerBackend;
+  QString audioPlaybackProgram;
 
   ProxyServer proxyServer;
 

--- a/ffmpegaudio.cc
+++ b/ffmpegaudio.cc
@@ -1,4 +1,4 @@
-#ifndef DISABLE_INTERNAL_PLAYER
+#ifdef MAKE_FFMPEG_PLAYER
 
 #include "ffmpegaudio.hh"
 
@@ -589,4 +589,4 @@ void DecoderThread::cancel( bool waitUntilFinished )
 
 }
 
-#endif //DISABLE_INTERNAL_PLAYER
+#endif // MAKE_FFMPEG_PLAYER

--- a/ffmpegaudio.hh
+++ b/ffmpegaudio.hh
@@ -1,7 +1,7 @@
 #ifndef __FFMPEGAUDIO_HH_INCLUDED__
 #define __FFMPEGAUDIO_HH_INCLUDED__
 
-#ifndef DISABLE_INTERNAL_PLAYER
+#ifdef MAKE_FFMPEG_PLAYER
 
 #include <QObject>
 #include <QMutex>
@@ -52,6 +52,6 @@ signals:
 
 }
 
-#endif // DISABLE_INTERNAL_PLAYER
+#endif // MAKE_FFMPEG_PLAYER
 
 #endif // __FFMPEGAUDIO_HH_INCLUDED__

--- a/ffmpegaudioplayer.hh
+++ b/ffmpegaudioplayer.hh
@@ -7,7 +7,7 @@
 #include "audioplayerinterface.hh"
 #include "ffmpegaudio.hh"
 
-#ifndef DISABLE_INTERNAL_PLAYER
+#ifdef MAKE_FFMPEG_PLAYER
 
 namespace Ffmpeg
 {
@@ -36,6 +36,6 @@ public:
 
 }
 
-#endif // DISABLE_INTERNAL_PLAYER
+#endif // MAKE_FFMPEG_PLAYER
 
 #endif // FFMPEGAUDIOPLAYER_HH_INCLUDED

--- a/goldendict.pro
+++ b/goldendict.pro
@@ -28,9 +28,19 @@ greaterThan(QT_MAJOR_VERSION, 4) {
           webkitwidgets \
           printsupport \
           help
+
+    # QMediaPlayer is not available in Qt4.
+    !CONFIG( no_qtmultimedia_player ) {
+      QT += multimedia
+      DEFINES += MAKE_QTMULTIMEDIA_PLAYER
+    }
 } else {
     QT += webkit
     CONFIG += help
+}
+
+!CONFIG( no_ffmpeg_player ) {
+  DEFINES += MAKE_FFMPEG_PLAYER
 }
 
 QT += sql
@@ -45,8 +55,6 @@ LIBS += \
         -lz \
         -lbz2 \
         -llzo2
-
-!isEmpty(DISABLE_INTERNAL_PLAYER): DEFINES += DISABLE_INTERNAL_PLAYER
 
 win32 {
     TARGET = GoldenDict
@@ -97,7 +105,7 @@ win32 {
     LIBS += -lvorbisfile \
         -lvorbis \
         -logg
-    isEmpty(DISABLE_INTERNAL_PLAYER) {
+    !CONFIG( no_ffmpeg_player ) {
         LIBS += -lao \
             -lavutil-gd \
             -lavformat-gd \
@@ -143,7 +151,7 @@ unix:!mac {
         vorbis \
         ogg \
         hunspell
-    isEmpty(DISABLE_INTERNAL_PLAYER) {
+    !CONFIG( no_ffmpeg_player ) {
         PKGCONFIG += ao \
             libavutil \
             libavformat \
@@ -193,7 +201,7 @@ mac {
         -logg \
         -lhunspell-1.6.1 \
         -llzo2
-    isEmpty(DISABLE_INTERNAL_PLAYER) {
+    !CONFIG( no_ffmpeg_player ) {
         LIBS += -lao \
             -lavutil-gd \
             -lavformat-gd \
@@ -267,6 +275,7 @@ HEADERS += folding.hh \
     audioplayerinterface.hh \
     audioplayerfactory.hh \
     ffmpegaudioplayer.hh \
+    multimediaaudioplayer.hh \
     externalaudioplayer.hh \
     externalviewer.hh \
     wordfinder.hh \
@@ -399,6 +408,7 @@ SOURCES += folding.cc \
     scanpopup.cc \
     articleview.cc \
     audioplayerfactory.cc \
+    multimediaaudioplayer.cc \
     externalaudioplayer.cc \
     externalviewer.cc \
     wordfinder.cc \

--- a/multimediaaudioplayer.cc
+++ b/multimediaaudioplayer.cc
@@ -1,0 +1,43 @@
+/* This file is (c) 2018 Igor Kushnir <igorkuo@gmail.com>
+ * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
+
+#ifdef MAKE_QTMULTIMEDIA_PLAYER
+
+#include <QByteArray>
+#include <QMediaContent>
+#include "multimediaaudioplayer.hh"
+
+MultimediaAudioPlayer::MultimediaAudioPlayer() :
+  player( 0, QMediaPlayer::StreamPlayback )
+{
+  typedef void( QMediaPlayer::* ErrorSignal )( QMediaPlayer::Error );
+  connect( &player, static_cast< ErrorSignal >( &QMediaPlayer::error ),
+           this, &MultimediaAudioPlayer::onMediaPlayerError );
+}
+
+QString MultimediaAudioPlayer::play( const char * data, int size )
+{
+  stop();
+
+  audioBuffer.setData( data, size );
+  if( !audioBuffer.open( QIODevice::ReadOnly ) )
+    return tr( "Couldn't open audio buffer for reading." );
+
+  player.setMedia( QMediaContent(), &audioBuffer );
+  player.play();
+  return QString();
+}
+
+void MultimediaAudioPlayer::stop()
+{
+  player.setMedia( QMediaContent() ); // Forget about audioBuffer.
+  audioBuffer.close();
+  audioBuffer.setData( QByteArray() ); // Free memory.
+}
+
+void MultimediaAudioPlayer::onMediaPlayerError()
+{
+  emit error( player.errorString() );
+}
+
+#endif // MAKE_QTMULTIMEDIA_PLAYER

--- a/multimediaaudioplayer.hh
+++ b/multimediaaudioplayer.hh
@@ -1,0 +1,32 @@
+/* This file is (c) 2018 Igor Kushnir <igorkuo@gmail.com>
+ * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
+
+#ifndef MULTIMEDIAAUDIOPLAYER_HH_INCLUDED
+#define MULTIMEDIAAUDIOPLAYER_HH_INCLUDED
+
+#ifdef MAKE_QTMULTIMEDIA_PLAYER
+
+#include <QBuffer>
+#include <QMediaPlayer>
+#include "audioplayerinterface.hh"
+
+class MultimediaAudioPlayer : public AudioPlayerInterface
+{
+  Q_OBJECT
+public:
+  MultimediaAudioPlayer();
+
+  virtual QString play( const char * data, int size );
+  virtual void stop();
+
+private slots:
+  void onMediaPlayerError();
+
+private:
+  QBuffer audioBuffer;
+  QMediaPlayer player; ///< Depends on audioBuffer.
+};
+
+#endif // MAKE_QTMULTIMEDIA_PLAYER
+
+#endif // MULTIMEDIAAUDIOPLAYER_HH_INCLUDED

--- a/preferences.cc
+++ b/preferences.cc
@@ -250,7 +250,7 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
     ui.useInternalPlayer->setChecked( true );
   else
 #endif
-    ui.useExternalPlayer->setChecked( p.useExternalPlayer );
+    ui.useExternalPlayer->setChecked( true );
 
   ui.audioPlaybackProgram->setText( p.audioPlaybackProgram );
 
@@ -399,7 +399,6 @@ Config::Preferences Preferences::getPreferences()
 
   p.pronounceOnLoadMain = ui.pronounceOnLoadMain->isChecked();
   p.pronounceOnLoadPopup = ui.pronounceOnLoadPopup->isChecked();
-  p.useExternalPlayer = ui.useExternalPlayer->isChecked();
   p.useInternalPlayer = ui.useInternalPlayer->isChecked();
   p.audioPlaybackProgram = ui.audioPlaybackProgram->text();
 

--- a/preferences.cc
+++ b/preferences.cc
@@ -243,14 +243,28 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
   ui.pronounceOnLoadMain->setChecked( p.pronounceOnLoadMain );
   ui.pronounceOnLoadPopup->setChecked( p.pronounceOnLoadPopup );
 
-#ifdef DISABLE_INTERNAL_PLAYER
-  ui.useInternalPlayer->hide();
-#else
-  if ( p.useInternalPlayer )
-    ui.useInternalPlayer->setChecked( true );
+  ui.internalPlayerBackend->addItems( Config::InternalPlayerBackend::nameList() );
+
+  // Make sure that exactly one radio button in the group is checked and that
+  // on_useExternalPlayer_toggled() is called.
+  ui.useExternalPlayer->setChecked( true );
+
+  if( ui.internalPlayerBackend->count() > 0 )
+  {
+    // Checking ui.useInternalPlayer automatically unchecks ui.useExternalPlayer.
+    ui.useInternalPlayer->setChecked( p.useInternalPlayer );
+
+    int index = ui.internalPlayerBackend->findText( p.internalPlayerBackend.uiName() );
+    if( index < 0 ) // The specified backend is unavailable.
+      index = ui.internalPlayerBackend->findText( Config::InternalPlayerBackend::defaultBackend().uiName() );
+    Q_ASSERT( index >= 0 && "Logic error: the default backend must be present in the backend name list." );
+    ui.internalPlayerBackend->setCurrentIndex( index );
+  }
   else
-#endif
-    ui.useExternalPlayer->setChecked( true );
+  {
+    ui.useInternalPlayer->hide();
+    ui.internalPlayerBackend->hide();
+  }
 
   ui.audioPlaybackProgram->setText( p.audioPlaybackProgram );
 
@@ -400,6 +414,7 @@ Config::Preferences Preferences::getPreferences()
   p.pronounceOnLoadMain = ui.pronounceOnLoadMain->isChecked();
   p.pronounceOnLoadPopup = ui.pronounceOnLoadPopup->isChecked();
   p.useInternalPlayer = ui.useInternalPlayer->isChecked();
+  p.internalPlayerBackend.setUiName( ui.internalPlayerBackend->currentText() );
   p.audioPlaybackProgram = ui.audioPlaybackProgram->text();
 
   p.proxyServer.enabled = ui.useProxyServer->isChecked();
@@ -592,6 +607,7 @@ void Preferences::on_buttonBox_accepted()
 
 void Preferences::on_useExternalPlayer_toggled( bool enabled )
 {
+  ui.internalPlayerBackend->setEnabled( !enabled );
   ui.audioPlaybackProgram->setEnabled( enabled );
 }
 

--- a/preferences.ui
+++ b/preferences.ui
@@ -902,37 +902,43 @@ p, li { white-space: pre-wrap; }
          <property name="title">
           <string>Playback</string>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_16">
-          <item>
+         <layout class="QGridLayout" name="gridLayout_audioPlayer">
+          <item row="0" column="0">
            <widget class="QRadioButton" name="useInternalPlayer">
             <property name="toolTip">
-             <string>Play audio files via FFmpeg(libav) and libao</string>
+             <string>Play audio files via built-in audio support</string>
             </property>
             <property name="text">
-             <string>Use internal player</string>
+             <string>Use internal player:</string>
             </property>
            </widget>
           </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_12">
-            <item>
-             <widget class="QRadioButton" name="useExternalPlayer">
-              <property name="toolTip">
-               <string>Use any external program to play audio files</string>
-              </property>
-              <property name="text">
-               <string>Use external program:</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLineEdit" name="audioPlaybackProgram">
-              <property name="enabled">
-               <bool>false</bool>
-              </property>
-             </widget>
-            </item>
-           </layout>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="internalPlayerBackend">
+            <property name="toolTip">
+             <string>Choose audio back end</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QRadioButton" name="useExternalPlayer">
+            <property name="toolTip">
+             <string>Use any external program to play audio files</string>
+            </property>
+            <property name="text">
+             <string>Use external program:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLineEdit" name="audioPlaybackProgram">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="toolTip">
+             <string>Enter audio player command line</string>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>


### PR DESCRIPTION
This is an additional feature - the old internal player back end is preserved as the default option. If this new back end works for everyone as well as it does for me, we can make it the default quite easily.

This pull request contains architectural changes that facilitate variable number of audio player back ends. Adding yet another back end should be easier than ever after these commits.

More detailed description is in commit messages.