### PR TITLE
mainwindow.ui: Assign "a" accel-key to Search

### DIFF
--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -133,7 +133,7 @@
    </widget>
    <widget class="QMenu" name="menuSearch">
     <property name="title">
-     <string>Search</string>
+     <string>Se&amp;arch</string>
     </property>
     <addaction name="searchInPageAction"/>
     <addaction name="fullTextSearchAction"/>


### PR DESCRIPTION
Currently "Search" menu has no accelerate key assigned with it. We might as well add one so that every entry in menubar could be opened through accel key.

I know that assigning "S" would cause conflict. As a result I chose "a" here.