### PR TITLE
Allow customizing unpinned scan popup window flags on X11 with Qt5

### DIFF
--- a/config.cc
+++ b/config.cc
@@ -128,6 +128,18 @@ bool InternalPlayerBackend::isQtmultimedia() const
 #endif
 }
 
+ScanPopupWindowFlags spwfFromInt( int id )
+{
+  if( id == SPWF_Popup )
+    return SPWF_Popup;
+  if( id == SPWF_Tool )
+    return SPWF_Tool;
+
+  if( id != SPWF_default )
+    gdWarning( "Invalid ScanPopup unpinned window flags: %d\n", id );
+  return SPWF_default;
+}
+
 Preferences::Preferences():
   newTabsOpenAfterCurrentOne( false ),
   newTabsOpenInBackground( true ),
@@ -158,6 +170,8 @@ Preferences::Preferences():
   scanPopupUseUIAutomation( true ),
   scanPopupUseIAccessibleEx( true ),
   scanPopupUseGDMessage( true ),
+  scanPopupUnpinnedWindowFlags( SPWF_default ),
+  scanPopupUnpinnedBypassWMHint( false ),
   scanToMainWindow( false ),
 #ifdef HAVE_X11
   showScanFlag( false ),
@@ -812,6 +826,8 @@ Class load() throw( exError )
     c.preferences.scanPopupUseUIAutomation = ( preferences.namedItem( "scanPopupUseUIAutomation" ).toElement().text() == "1" );
     c.preferences.scanPopupUseIAccessibleEx = ( preferences.namedItem( "scanPopupUseIAccessibleEx" ).toElement().text() == "1" );
     c.preferences.scanPopupUseGDMessage = ( preferences.namedItem( "scanPopupUseGDMessage" ).toElement().text() == "1" );
+    c.preferences.scanPopupUnpinnedWindowFlags = spwfFromInt( preferences.namedItem( "scanPopupUnpinnedWindowFlags" ).toElement().text().toInt() );
+    c.preferences.scanPopupUnpinnedBypassWMHint = ( preferences.namedItem( "scanPopupUnpinnedBypassWMHint" ).toElement().text() == "1" );
 
     c.preferences.pronounceOnLoadMain = ( preferences.namedItem( "pronounceOnLoadMain" ).toElement().text() == "1" );
     c.preferences.pronounceOnLoadPopup = ( preferences.namedItem( "pronounceOnLoadPopup" ).toElement().text() == "1" );
@@ -1700,6 +1716,14 @@ void save( Class const & c ) throw( exError )
 
     opt = dd.createElement( "scanPopupUseGDMessage" );
     opt.appendChild( dd.createTextNode( c.preferences.scanPopupUseGDMessage ? "1":"0" ) );
+    preferences.appendChild( opt );
+
+    opt = dd.createElement( "scanPopupUnpinnedWindowFlags" );
+    opt.appendChild( dd.createTextNode( QString::number( c.preferences.scanPopupUnpinnedWindowFlags ) ) );
+    preferences.appendChild( opt );
+
+    opt = dd.createElement( "scanPopupUnpinnedBypassWMHint" );
+    opt.appendChild( dd.createTextNode( c.preferences.scanPopupUnpinnedBypassWMHint ? "1":"0" ) );
     preferences.appendChild( opt );
 
     opt = dd.createElement( "pronounceOnLoadMain" );

--- a/config.hh
+++ b/config.hh
@@ -225,6 +225,23 @@ private:
   QString name;
 };
 
+#if defined( HAVE_X11 ) && QT_VERSION >= QT_VERSION_CHECK( 5, 0, 0 )
+  // The ScanPopup window flags customization code has been tested
+  // only in X11 desktop environments and window managers.
+  // None of the window flags configurations I have tried works perfectly well
+  // in XFCE with Qt4. Let us enable customization code for Qt5 exclusively to
+  // avoid regressions with Qt4.
+  #define ENABLE_SPWF_CUSTOMIZATION
+#endif
+
+enum ScanPopupWindowFlags
+{
+  SPWF_default = 0,
+  SPWF_Popup,
+  SPWF_Tool
+};
+ScanPopupWindowFlags spwfFromInt( int id );
+
 /// Various user preferences
 struct Preferences
 {
@@ -263,6 +280,8 @@ struct Preferences
   bool scanPopupUseUIAutomation;
   bool scanPopupUseIAccessibleEx;
   bool scanPopupUseGDMessage;
+  ScanPopupWindowFlags scanPopupUnpinnedWindowFlags;
+  bool scanPopupUnpinnedBypassWMHint;
   bool scanToMainWindow;
 #ifdef HAVE_X11
   bool showScanFlag;

--- a/preferences.cc
+++ b/preferences.cc
@@ -191,6 +191,8 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
   ui.scanPopupUseUIAutomation->setChecked( p.scanPopupUseUIAutomation );
   ui.scanPopupUseIAccessibleEx->setChecked( p.scanPopupUseIAccessibleEx );
   ui.scanPopupUseGDMessage->setChecked( p.scanPopupUseGDMessage );
+  ui.scanPopupUnpinnedWindowFlags->setCurrentIndex( p.scanPopupUnpinnedWindowFlags );
+  ui.scanPopupUnpinnedBypassWMHint->setChecked( p.scanPopupUnpinnedBypassWMHint );
 
   ui.storeHistory->setChecked( p.storeHistory );
   ui.historyMaxSizeField->setValue( p.maxStringsInHistory );
@@ -230,6 +232,10 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
 #ifndef Q_OS_WIN32
   ui.groupBox_ScanPopupTechnologies->hide();
 //  ui.tabWidget->removeTab( 5 );
+#endif
+
+#ifndef ENABLE_SPWF_CUSTOMIZATION
+  ui.groupBox_ScanPopupWindowFlags->hide();
 #endif
 
 #ifdef HAVE_X11
@@ -395,6 +401,8 @@ Config::Preferences Preferences::getPreferences()
   p.scanPopupUseUIAutomation = ui.scanPopupUseUIAutomation->isChecked();
   p.scanPopupUseIAccessibleEx = ui.scanPopupUseIAccessibleEx->isChecked();
   p.scanPopupUseGDMessage = ui.scanPopupUseGDMessage->isChecked();
+  p.scanPopupUnpinnedWindowFlags = Config::spwfFromInt( ui.scanPopupUnpinnedWindowFlags->currentIndex() );
+  p.scanPopupUnpinnedBypassWMHint = ui.scanPopupUnpinnedBypassWMHint->isChecked();
 
   p.storeHistory = ui.storeHistory->isChecked();
   p.maxStringsInHistory = ui.historyMaxSizeField->text().toUInt();
@@ -541,6 +549,11 @@ void Preferences::showScanFlagToggled( bool b )
 {
   if( b )
     ui.enableScanPopupModifiers->setChecked( false );
+}
+
+void Preferences::on_scanPopupUnpinnedWindowFlags_currentIndexChanged( int index )
+{
+  ui.scanPopupUnpinnedBypassWMHint->setEnabled( Config::spwfFromInt( index ) != Config::SPWF_default );
 }
 
 void Preferences::wholeAltClicked( bool b )

--- a/preferences.hh
+++ b/preferences.hh
@@ -34,6 +34,7 @@ private slots:
   void enableScanPopupToggled( bool );
   void enableScanPopupModifiersToggled( bool );
   void showScanFlagToggled( bool b );
+  void on_scanPopupUnpinnedWindowFlags_currentIndexChanged( int index );
 
   void wholeAltClicked( bool );
   void wholeCtrlClicked( bool );

--- a/preferences.ui
+++ b/preferences.ui
@@ -1370,50 +1370,124 @@ download page.</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_11">
        <item>
-        <widget class="QGroupBox" name="groupBox_ScanPopupTechnologies">
-         <property name="title">
-          <string>ScanPopup extra technologies</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_13">
-          <item>
-           <widget class="QCheckBox" name="scanPopupUseIAccessibleEx">
-            <property name="toolTip">
-             <string>Try to use IAccessibleEx technology to retrieve word under cursor.
+        <layout class="QHBoxLayout" name="horizontalLayout_17">
+         <item>
+          <widget class="QGroupBox" name="groupBox_ScanPopupTechnologies">
+           <property name="title">
+            <string>ScanPopup extra technologies</string>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_13">
+            <item>
+             <widget class="QCheckBox" name="scanPopupUseIAccessibleEx">
+              <property name="toolTip">
+               <string>Try to use IAccessibleEx technology to retrieve word under cursor.
 This technology works only with some programs that support it
  (for example Internet Explorer 9).
 It is not needed to select this option if you don't use such programs.</string>
-            </property>
-            <property name="text">
-             <string>Use &amp;IAccessibleEx</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="scanPopupUseUIAutomation">
-            <property name="toolTip">
-             <string>Try to use UI Automation technology to retrieve word under cursor.
+              </property>
+              <property name="text">
+               <string>Use &amp;IAccessibleEx</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="scanPopupUseUIAutomation">
+              <property name="toolTip">
+               <string>Try to use UI Automation technology to retrieve word under cursor.
 This technology works only with some programs that support it.
 It is not needed to select this option if you don't use such programs.</string>
-            </property>
-            <property name="text">
-             <string>Use &amp;UIAutomation</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="scanPopupUseGDMessage">
-            <property name="toolTip">
-             <string>Try to use special GoldenDict message to retrieve word under cursor.
+              </property>
+              <property name="text">
+               <string>Use &amp;UIAutomation</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="scanPopupUseGDMessage">
+              <property name="toolTip">
+               <string>Try to use special GoldenDict message to retrieve word under cursor.
 This technology works only with some programs that support it.
 It is not needed to select this option if you don't use such programs.</string>
-            </property>
-            <property name="text">
-             <string>Use &amp;GoldenDict message</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
+              </property>
+              <property name="text">
+               <string>Use &amp;GoldenDict message</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QGroupBox" name="groupBox_ScanPopupWindowFlags">
+           <property name="title">
+            <string>ScanPopup unpinned window flags</string>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_22">
+            <item>
+             <widget class="QComboBox" name="scanPopupUnpinnedWindowFlags">
+              <property name="toolTip">
+               <string>Experiment with non-default flags if the unpinned scan popup window misbehaves</string>
+              </property>
+              <item>
+               <property name="text">
+                <string>&lt;default&gt;</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Popup</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Tool</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="scanPopupUnpinnedBypassWMHint">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="toolTip">
+               <string>This hint can be combined with non-default window flags</string>
+              </property>
+              <property name="text">
+               <string>Bypass window manager hint</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer_18">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_13">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
        </item>
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_15">

--- a/scanpopup.cc
+++ b/scanpopup.cc
@@ -906,7 +906,7 @@ void ScanPopup::requestWindowFocus()
   // One of the rare, actually working workarounds for requesting a user keyboard focus on X11,
   // works for Qt::Popup windows, exactly like our Scan Popup (in unpinned state).
   // Modern window managers actively resist to automatically focus pop-up windows.
-#ifdef HAVE_X11
+#if defined HAVE_X11 && QT_VERSION < QT_VERSION_CHECK( 5, 0, 0 )
   if ( !ui.pinButton->isChecked() )
   {
     QMenu m( this );

--- a/scanpopup.hh
+++ b/scanpopup.hh
@@ -108,6 +108,8 @@ public slots:
 
 private:
 
+  Qt::WindowFlags unpinnedWindowFlags() const;
+
   // Translates the word from the clipboard or the clipboard selection
   void translateWordFromClipboard(QClipboard::Mode m);
 


### PR DESCRIPTION
This pull request allows a user to get rid of #645 by selecting an option suitable for his/her preferred desktop environment or window manager. See the commit messages for more details.

Attached a spreadsheet with my test results: [ScanPopupTests.ods.zip](https://github.com/goldendict/goldendict/files/1913081/ScanPopupTests.ods.zip).
