### PR TITLE
add possibility to use icon from system theme for tray icon

### DIFF
--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -590,7 +590,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   if ( cfg.preferences.enableTrayIcon )
   {
-    trayIcon = new QSystemTrayIcon( QIcon( ":/icons/programicon_old.png" ), this );
+    trayIcon = new QSystemTrayIcon( QIcon::fromTheme("goldendict-tray", QIcon( ":/icons/programicon_old.png" )), this );
     trayIcon->setToolTip( tr( "Loading..." ) );
     trayIcon->show();
   }
@@ -1113,7 +1113,7 @@ void MainWindow::updateTrayIcon()
   if ( !trayIcon && cfg.preferences.enableTrayIcon )
   {
     // Need to show it
-    trayIcon = new QSystemTrayIcon( QIcon( ":/icons/programicon_old.png" ), this );
+    trayIcon = new QSystemTrayIcon( QIcon::fromTheme("goldendict-tray", QIcon( ":/icons/programicon_old.png" )), this );
     trayIcon->setContextMenu( &trayIconMenu );
     trayIcon->show();
 
@@ -1131,10 +1131,9 @@ void MainWindow::updateTrayIcon()
   if ( trayIcon )
   {
     // Update the icon to reflect the scanning mode
-    trayIcon->setIcon( QIcon(
-      enableScanPopup->isChecked() ?
-        ":/icons/programicon_scan.png" :
-        ":/icons/programicon_old.png" ) );
+    trayIcon->setIcon( enableScanPopup->isChecked() ?
+        QIcon::fromTheme("goldendict-scan-tray", QIcon( ":/icons/programicon_scan.png" )) :
+        QIcon::fromTheme("goldendict-tray", QIcon( ":/icons/programicon_old.png" )) );
 
     trayIcon->setToolTip( "GoldenDict" );
   }


### PR DESCRIPTION
this fix #873 and #804. it needs that icon themes have two icons with the names: goldendict-tray and goldendict-scan-tray. if they don't. it fallback to use original icons from icon folder.
I create an issue in papirus icon theme to add these to their icons. 
https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/issues/1224