### PR TITLE
Small audio player fixes

### DIFF
--- a/audioplayerfactory.cc
+++ b/audioplayerfactory.cc
@@ -60,14 +60,14 @@ void AudioPlayerFactory::reset()
 
     if( !internalPlayerBackend.isQtmultimedia() )
     {
-      if( qobject_cast< Ffmpeg::AudioPlayer * >( playerPtr.data() ) == 0 )
+      if( !playerPtr || !qobject_cast< Ffmpeg::AudioPlayer * >( playerPtr.data() ) )
         playerPtr.reset( new Ffmpeg::AudioPlayer );
       return;
     }
 #endif
 
 #ifdef MAKE_QTMULTIMEDIA_PLAYER
-    if( qobject_cast< MultimediaAudioPlayer * >( playerPtr.data() ) == 0 )
+    if( !playerPtr || !qobject_cast< MultimediaAudioPlayer * >( playerPtr.data() ) )
       playerPtr.reset( new MultimediaAudioPlayer );
     return;
 #endif

--- a/ffmpegaudioplayer.hh
+++ b/ffmpegaudioplayer.hh
@@ -22,6 +22,11 @@ public:
              this, SIGNAL( error( QString ) ) );
   }
 
+  ~AudioPlayer()
+  {
+    stop();
+  }
+
   virtual QString play( const char * data, int size )
   {
     AudioService::instance().playMemory( data, size );


### PR DESCRIPTION
These fixes eliminate a rare wrong behavior and a crash when goldendict is compiled with sanitization (diagnostic) option.
See commit messages for individual fix descriptions.