### PR TITLE
Move scanToMainWindow checkbox out of enableScanPopup group box

### DIFF
--- a/preferences.ui
+++ b/preferences.ui
@@ -670,16 +670,6 @@ seconds, which is specified here.</string>
            </layout>
           </item>
           <item>
-           <widget class="QCheckBox" name="scanToMainWindow">
-            <property name="toolTip">
-             <string>Send translated word to main window instead of to show it in popup window</string>
-            </property>
-            <property name="text">
-             <string>Send translated word to main window</string>
-            </property>
-           </widget>
-          </item>
-          <item>
            <widget class="QCheckBox" name="showScanFlag">
             <property name="toolTip">
              <string>Show a flag window before showing popup window, click the flag to show popup window. </string>
@@ -690,6 +680,16 @@ seconds, which is specified here.</string>
            </widget>
           </item>
          </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="scanToMainWindow">
+         <property name="toolTip">
+          <string>Send translated word to main window instead of to show it in popup window</string>
+         </property>
+         <property name="text">
+          <string>Send translated word to main window</string>
+         </property>
         </widget>
        </item>
        <item>


### PR DESCRIPTION
This option has effect even when scan popup functionality is disabled -
when the Ctrl+C+C hotkey is triggered. So the scanToMainWindow checkbox
should not be disabled when enableScanPopup is unchecked. Fixes #716.