### PR TITLE
Eliminate a redundant makeScanPopup() call

### DIFF
--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -2109,7 +2109,6 @@ void MainWindow::editPreferences()
     updateTrayIcon();
     applyProxySettings();
     applyWebSettings();
-    makeScanPopup();
 
     ui.tabWidget->setHideSingleTab(cfg.preferences.hideSingleTab);
 


### PR DESCRIPTION
Destroying and creating a scan popup instance twice in
MainWindow::editPreferences() is wasteful.

2b9dd558046670f566cb78e9536b4d5556c3af48 added the unconditional second
makeScanPopup() call below but didn't remove the existing call,
probably by mistake.