### PR TITLE
Pronounce button: stop if already playing

### DIFF
--- a/articleview.cc
+++ b/articleview.cc
@@ -1610,6 +1610,11 @@ void ArticleView::playSound()
     openLink( QUrl::fromEncoded( soundScript.toUtf8() ), ui.definition->url() );
 }
 
+void ArticleView::stopPlayback()
+{
+  audioPlayer->stop();
+}
+
 QString ArticleView::toHtml()
 {
   return ui.definition->page()->mainFrame()->toHtml();

--- a/articleview.hh
+++ b/articleview.hh
@@ -152,6 +152,9 @@ public:
   /// Plays the first audio reference on the page, if any.
   void playSound();
 
+  /// Stops current playback if any.
+  void stopPlayback();
+
   void setZoomFactor( qreal factor )
   { ui.definition->setZoomFactor( factor ); }
 

--- a/articleview.hh
+++ b/articleview.hh
@@ -114,7 +114,10 @@ public:
   /// contexts is an optional map of context values to be passed for dictionaries.
   /// The only values to pass here are ones obtained from showDefinitionInNewTab()
   /// signal or none at all.
-  void openLink( QUrl const & url, QUrl const & referrer,
+  /// Returns false if the url scheme is unrecognized or the referenced resource
+  /// doesn't exist or if the resource failed to download. Returns true otherwise:
+  /// on success, if some other error occurs or if the resource is being downloaded asynchronously.
+  bool openLink( QUrl const & url, QUrl const & referrer,
                  QString const & scrollTo = QString(),
                  Contexts const & contexts = Contexts() );
 
@@ -150,7 +153,9 @@ public:
   bool hasSound();
 
   /// Plays the first audio reference on the page, if any.
-  void playSound();
+  /// Returns false if there is no audio reference on the page, if the referenced
+  /// audio resource doesn't exist or if it failed to download; true otherwise.
+  bool playSound();
 
   /// Stops current playback if any.
   void stopPlayback();
@@ -265,7 +270,8 @@ private slots:
   void linkHovered( const QString & link, const QString & title, const QString & textContent );
   void contextMenuRequested( QPoint const & );
 
-  void resourceDownloadFinished();
+  /// Returns false if all requests are finished and none has any data; true otherwise.
+  bool resourceDownloadFinished();
 
   /// We handle pasting by attempting to define the word in clipboard.
   void pasteTriggered();

--- a/audioplayerinterface.hh
+++ b/audioplayerinterface.hh
@@ -12,17 +12,28 @@ class AudioPlayerInterface : public QObject
 {
   Q_OBJECT
 public:
+  enum State { StoppedState, PlayingState };
+
   /// Stops current playback if any, copies the audio buffer at [data, data + size),
   /// then plays this buffer. It is safe to invalidate \p data after this function call.
+  /// Always emits at least one stateChanged() signal.
   /// Returns an error message in case of immediate failure; an empty string
   /// in case of success.
   virtual QString play( const char * data, int size ) = 0;
-  /// Stops current playback if any.
+  /// Stops current playback if any. Always emits stateChanged( StoppedState ).
   virtual void stop() = 0;
 
 signals:
   /// Notifies of asynchronous errors.
   void error( QString message );
+
+  /// Is emitted whenever playback is started or stopped.
+  /// Note: this signal may be emitted more than once in a row with the same or
+  /// different state values. Prohibiting such redundant signals would
+  /// complicate implementations significantly.
+  /// Note: fully qualified AudioPlayerInterface::State must be used below.
+  /// Unqualified State breaks connections from other classes at runtime.
+  void stateChanged( AudioPlayerInterface::State state );
 };
 
 typedef QScopedPointer< AudioPlayerInterface > AudioPlayerPtr;

--- a/audioplayerui.hh
+++ b/audioplayerui.hh
@@ -1,0 +1,56 @@
+/* This file is (c) 2018 Igor Kushnir <igorkuo@gmail.com>
+ * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
+
+#ifndef AUDIOPLAYERUI_HH_INCLUDED
+#define AUDIOPLAYERUI_HH_INCLUDED
+
+#include "audioplayerinterface.hh"
+
+/// This class template ensures that its managed checkable audio UI element
+/// is interactable when checked to allow stopping playback at any time.
+/// When the UI element becomes unchecked after a setPlaybackState() call, the
+/// proper interactability based on playability, as specified by the last
+/// setPlayable() call, is restored.
+template< class CheckableUiElement >
+class AudioPlayerUi
+{
+  Q_DISABLE_COPY( AudioPlayerUi )
+public:
+  /// This pointer to member typically points to setEnabled() or setVisible().
+  typedef void ( CheckableUiElement::* SetInteractablePtr )( bool );
+
+  explicit AudioPlayerUi( CheckableUiElement & audioUiElement,
+                          SetInteractablePtr setInteractablePtr ) :
+    uiElement( audioUiElement ),
+    setInteractable( setInteractablePtr ),
+    interactableWhenUnchecked( true )
+  {}
+
+  AudioPlayerInterface::State playbackState() const
+  {
+    return uiElement.isChecked() ? AudioPlayerInterface::PlayingState
+                                 : AudioPlayerInterface::StoppedState;
+  }
+
+  void setPlaybackState( AudioPlayerInterface::State state )
+  {
+    const bool checked = ( state == AudioPlayerInterface::PlayingState );
+    uiElement.setChecked( checked );
+    if( checked || !interactableWhenUnchecked )
+      ( uiElement.*setInteractable )( checked );
+  }
+
+  void setPlayable( bool playable )
+  {
+    interactableWhenUnchecked = playable;
+    if( !uiElement.isChecked() )
+      ( uiElement.*setInteractable )( interactableWhenUnchecked );
+  }
+
+private:
+  CheckableUiElement & uiElement;
+  const SetInteractablePtr setInteractable;
+  bool interactableWhenUnchecked;
+};
+
+#endif // AUDIOPLAYERUI_HH_INCLUDED

--- a/audioplayerui.hh
+++ b/audioplayerui.hh
@@ -55,11 +55,20 @@ private:
   bool interactableWhenUnchecked;
 };
 
-inline QString pronounceActionText( AudioPlayerInterface::State state )
+/// This class caches two frequently swapped texts/tooltips for pronounce actions/buttons.
+class PronounceActionTexts
 {
-  return state == AudioPlayerInterface::PlayingState ?
-        QCoreApplication::translate( "AudioPlayerUi", "Stop Pronouncing (Alt+S)" )
-      : QCoreApplication::translate( "AudioPlayerUi", "Pronounce Word (Alt+S)" );
-}
+public:
+  PronounceActionTexts() :
+    stoppedText( QCoreApplication::translate( "AudioPlayerUi", "Pronounce Word (Alt+S)" ) ),
+    playingText( QCoreApplication::translate( "AudioPlayerUi", "Stop Pronouncing (Alt+S)" ) )
+  {}
+
+  QString const & textFor( AudioPlayerInterface::State state ) const
+  { return state == AudioPlayerInterface::PlayingState ? playingText : stoppedText; }
+
+private:
+  const QString stoppedText, playingText;
+};
 
 #endif // AUDIOPLAYERUI_HH_INCLUDED

--- a/audioplayerui.hh
+++ b/audioplayerui.hh
@@ -4,6 +4,8 @@
 #ifndef AUDIOPLAYERUI_HH_INCLUDED
 #define AUDIOPLAYERUI_HH_INCLUDED
 
+#include <QString>
+#include <QCoreApplication>
 #include "audioplayerinterface.hh"
 
 /// This class template ensures that its managed checkable audio UI element
@@ -52,5 +54,12 @@ private:
   const SetInteractablePtr setInteractable;
   bool interactableWhenUnchecked;
 };
+
+inline QString pronounceActionText( AudioPlayerInterface::State state )
+{
+  return state == AudioPlayerInterface::PlayingState ?
+        QCoreApplication::translate( "AudioPlayerUi", "Stop Pronouncing (Alt+S)" )
+      : QCoreApplication::translate( "AudioPlayerUi", "Pronounce Word (Alt+S)" );
+}
 
 #endif // AUDIOPLAYERUI_HH_INCLUDED

--- a/externalaudioplayer.hh
+++ b/externalaudioplayer.hh
@@ -26,6 +26,7 @@ private slots:
   void onViewerDestroyed( QObject * destroyedViewer );
 
 private:
+  /// Returns an error message and resets viewer to null in case of an error.
   QString startViewer();
 
   QString playerCommandLine;

--- a/ffmpegaudio.hh
+++ b/ffmpegaudio.hh
@@ -24,10 +24,17 @@ public:
 signals:
   void cancelPlaying( bool waitUntilFinished );
   void error( QString const & message );
+  /// Is emitted when playback actually ends (not when stop is requested).
+  void playbackStopped();
+
+private slots:
+  void onThreadDestroyed();
 
 private:
   AudioService();
   ~AudioService();
+
+  int runningThreadCount;
 };
 
 class DecoderThread: public QThread

--- a/ffmpegaudioplayer.hh
+++ b/ffmpegaudioplayer.hh
@@ -20,6 +20,8 @@ public:
   {
     connect( &AudioService::instance(), SIGNAL( error( QString ) ),
              this, SIGNAL( error( QString ) ) );
+    connect( &AudioService::instance(), SIGNAL( playbackStopped() ),
+             this, SLOT( onPlaybackStopped() ) );
   }
 
   ~AudioPlayer()
@@ -30,12 +32,20 @@ public:
   virtual QString play( const char * data, int size )
   {
     AudioService::instance().playMemory( data, size );
+    emit stateChanged( PlayingState );
     return QString();
   }
 
   virtual void stop()
   {
     AudioService::instance().stop();
+    emit stateChanged( StoppedState );
+  }
+
+private slots:
+  void onPlaybackStopped()
+  {
+    emit stateChanged( StoppedState );
   }
 };
 

--- a/goldendict.pro
+++ b/goldendict.pro
@@ -272,6 +272,7 @@ HEADERS += folding.hh \
     article_maker.hh \
     scanpopup.hh \
     articleview.hh \
+    audioplayerui.hh \
     audioplayerinterface.hh \
     audioplayerfactory.hh \
     ffmpegaudioplayer.hh \

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -206,7 +206,8 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   navToolbar->widgetForAction( afterScanPopupSeparator )->setObjectName( "afterScanPopupSeparator" );
 
   // sound
-  navPronounce = navToolbar->addAction( QIcon( ":/icons/playsound_full.png" ), tr( "Pronounce Word (Alt+S)" ) );
+  navPronounce = navToolbar->addAction( QIcon( ":/icons/playsound_full.png" ),
+                                        pronounceActionText( AudioPlayerInterface::StoppedState ) );
   navPronounce->setShortcut( QKeySequence( "Alt+S" ) );
   navPronounce->setCheckable( true );
   navToolbar->widgetForAction( navPronounce )->setObjectName( "soundButton" );
@@ -1870,6 +1871,7 @@ void MainWindow::connectToAudioPlayer()
 void MainWindow::onAudioPlayerStateChanged( AudioPlayerInterface::State state )
 {
   audioPlayerUi->setPlaybackState( state );
+  navPronounce->setText( pronounceActionText( state ) );
   if( scanPopup )
     scanPopup->setPlaybackState( state );
 }

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -207,7 +207,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   // sound
   navPronounce = navToolbar->addAction( QIcon( ":/icons/playsound_full.png" ),
-                                        pronounceActionText( AudioPlayerInterface::StoppedState ) );
+                                        pronounceActionTexts.textFor( AudioPlayerInterface::StoppedState ) );
   navPronounce->setShortcut( QKeySequence( "Alt+S" ) );
   navPronounce->setCheckable( true );
   navToolbar->widgetForAction( navPronounce )->setObjectName( "soundButton" );
@@ -1871,7 +1871,7 @@ void MainWindow::connectToAudioPlayer()
 void MainWindow::onAudioPlayerStateChanged( AudioPlayerInterface::State state )
 {
   audioPlayerUi->setPlaybackState( state );
-  navPronounce->setText( pronounceActionText( state ) );
+  navPronounce->setText( pronounceActionTexts.textFor( state ) );
   if( scanPopup )
     scanPopup->setPlaybackState( state );
 }

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -1857,7 +1857,10 @@ void MainWindow::onPronounceTriggered( bool checked )
   ArticleView * const view = getCurrentArticleView();
   Q_ASSERT( view );
   if( checked )
-    view->playSound();
+  {
+    if( !view->playSound() ) // This pronunciation request failed before reaching the audio player.
+      navPronounce->setChecked( false ); // This is the only opportunity to fix the checked state.
+  }
   else
     view->stopPlayback();
 }

--- a/mainwindow.hh
+++ b/mainwindow.hh
@@ -156,9 +156,10 @@ private:
                                     // since their requests can be destroyed
                                     // in a separate thread
 
-  // audioPlayerUi must be destroyed after audioPlayerFactory because
+  // audioPlayerUi and pronounceActionTexts must be destroyed after audioPlayerFactory because
   // AudioPlayerInterface::stateChanged() may be emitted from its destructor.
   QScopedPointer< AudioPlayerUi< QAction > > audioPlayerUi;
+  PronounceActionTexts pronounceActionTexts;
   AudioPlayerFactory audioPlayerFactory;
 
   WordList * wordList;

--- a/mainwindow.hh
+++ b/mainwindow.hh
@@ -15,6 +15,7 @@
 #include "config.hh"
 #include "dictionary.hh"
 #include "article_netmgr.hh"
+#include "audioplayerinterface.hh"
 #include "audioplayerfactory.hh"
 #include "instances.hh"
 #include "article_maker.hh"
@@ -253,6 +254,8 @@ private:
 
   QString unescapeTabHeader( QString const & header );
 
+  void connectToAudioPlayer();
+
 private slots:
 
   void hotKeyActivated( int );
@@ -328,10 +331,9 @@ private slots:
 
   void dictionaryBarToggled( bool checked );
 
-  /// Pronounces the currently displayed word by playing its first audio
-  /// reference, if it has any.
-  /// If view is 0, the operation is done for the currently open tab.
-  void pronounce( ArticleView * view = 0 );
+  void onPronounceTriggered( bool checked );
+
+  void onAudioPlayerStateChanged( AudioPlayerInterface::State state );
 
   void zoomin();
   void zoomout();

--- a/mainwindow.hh
+++ b/mainwindow.hh
@@ -5,6 +5,7 @@
 #define __MAINWINDOW_HH_INCLUDED__
 
 #include <QMainWindow>
+#include <QScopedPointer>
 #include <QThread>
 #include <QToolButton>
 #include <QSystemTrayIcon>
@@ -16,6 +17,7 @@
 #include "dictionary.hh"
 #include "article_netmgr.hh"
 #include "audioplayerinterface.hh"
+#include "audioplayerui.hh"
 #include "audioplayerfactory.hh"
 #include "instances.hh"
 #include "article_maker.hh"
@@ -153,6 +155,10 @@ private:
   QNetworkAccessManager dictNetMgr; // We give dictionaries a separate manager,
                                     // since their requests can be destroyed
                                     // in a separate thread
+
+  // audioPlayerUi must be destroyed after audioPlayerFactory because
+  // AudioPlayerInterface::stateChanged() may be emitted from its destructor.
+  QScopedPointer< AudioPlayerUi< QAction > > audioPlayerUi;
   AudioPlayerFactory audioPlayerFactory;
 
   WordList * wordList;

--- a/multimediaaudioplayer.cc
+++ b/multimediaaudioplayer.cc
@@ -13,6 +13,9 @@ MultimediaAudioPlayer::MultimediaAudioPlayer() :
   typedef void( QMediaPlayer::* ErrorSignal )( QMediaPlayer::Error );
   connect( &player, static_cast< ErrorSignal >( &QMediaPlayer::error ),
            this, &MultimediaAudioPlayer::onMediaPlayerError );
+
+  connect( &player, &QMediaPlayer::stateChanged,
+           this, &MultimediaAudioPlayer::onMediaPlayerStateChanged );
 }
 
 QString MultimediaAudioPlayer::play( const char * data, int size )
@@ -33,11 +36,18 @@ void MultimediaAudioPlayer::stop()
   player.setMedia( QMediaContent() ); // Forget about audioBuffer.
   audioBuffer.close();
   audioBuffer.setData( QByteArray() ); // Free memory.
+
+  emit stateChanged( StoppedState ); // Always emit the signal as promised by our API.
 }
 
 void MultimediaAudioPlayer::onMediaPlayerError()
 {
   emit error( player.errorString() );
+}
+
+void MultimediaAudioPlayer::onMediaPlayerStateChanged( QMediaPlayer::State state )
+{
+  emit stateChanged( state == QMediaPlayer::PlayingState ? PlayingState : StoppedState );
 }
 
 #endif // MAKE_QTMULTIMEDIA_PLAYER

--- a/multimediaaudioplayer.hh
+++ b/multimediaaudioplayer.hh
@@ -21,6 +21,7 @@ public:
 
 private slots:
   void onMediaPlayerError();
+  void onMediaPlayerStateChanged( QMediaPlayer::State state );
 
 private:
   QBuffer audioBuffer;

--- a/scanpopup.cc
+++ b/scanpopup.cc
@@ -479,6 +479,11 @@ void ScanPopup::translateWord( QString const & word )
       );
 }
 
+void ScanPopup::setPlaybackState( AudioPlayerInterface::State state )
+{
+  ui.pronounceButton->setChecked( state == AudioPlayerInterface::PlayingState );
+}
+
 #ifdef HAVE_X11
 void ScanPopup::delayShow()
 {
@@ -1009,9 +1014,12 @@ void ScanPopup::prefixMatchFinished()
   }
 }
 
-void ScanPopup::on_pronounceButton_clicked()
+void ScanPopup::on_pronounceButton_clicked( bool checked )
 {
-  definition->playSound();
+  if( checked )
+    definition->playSound();
+  else
+    definition->stopPlayback();
 }
 
 void ScanPopup::pinButtonClicked( bool checked )

--- a/scanpopup.cc
+++ b/scanpopup.cc
@@ -140,7 +140,7 @@ ScanPopup::ScanPopup( QWidget * parent,
   connect( ui.translateBox->wordList(), SIGNAL( statusBarMessage( QString const &, int, QPixmap const & ) ),
            this, SLOT( showStatusBarMessage( QString const &, int, QPixmap const & ) ) );
 
-  ui.pronounceButton->setToolTip( pronounceActionText( AudioPlayerInterface::StoppedState ) );
+  ui.pronounceButton->setToolTip( pronounceActionTexts.textFor( AudioPlayerInterface::StoppedState ) );
   audioPlayerUi.reset( new AudioPlayerUi< QToolButton >( *ui.pronounceButton, &QToolButton::setVisible ) );
   audioPlayerUi->setPlayable( false );
 
@@ -484,7 +484,13 @@ void ScanPopup::translateWord( QString const & word )
 void ScanPopup::setPlaybackState( AudioPlayerInterface::State state )
 {
   audioPlayerUi->setPlaybackState( state );
-  ui.pronounceButton->setToolTip( pronounceActionText( state ) );
+
+  QString const & newToolTip = pronounceActionTexts.textFor( state );
+  // The same state - Stopped - is often set repeatedly.
+  // Unfortunately QWidget::setToolTip() doesn't check for string equality and
+  // always sends a ToolTipChange event. Let us optimize for our use case manually.
+  if( ui.pronounceButton->toolTip() != newToolTip )
+    ui.pronounceButton->setToolTip( newToolTip );
 }
 
 #ifdef HAVE_X11

--- a/scanpopup.cc
+++ b/scanpopup.cc
@@ -140,7 +140,8 @@ ScanPopup::ScanPopup( QWidget * parent,
   connect( ui.translateBox->wordList(), SIGNAL( statusBarMessage( QString const &, int, QPixmap const & ) ),
            this, SLOT( showStatusBarMessage( QString const &, int, QPixmap const & ) ) );
 
-  ui.pronounceButton->hide();
+  audioPlayerUi.reset( new AudioPlayerUi< QToolButton >( *ui.pronounceButton, &QToolButton::setVisible ) );
+  audioPlayerUi->setPlayable( false );
 
   ui.groupList->fill( groups );
   ui.groupList->setCurrentGroup( cfg.lastPopupGroupId );
@@ -481,7 +482,7 @@ void ScanPopup::translateWord( QString const & word )
 
 void ScanPopup::setPlaybackState( AudioPlayerInterface::State state )
 {
-  ui.pronounceButton->setChecked( state == AudioPlayerInterface::PlayingState );
+  audioPlayerUi->setPlaybackState( state );
 }
 
 #ifdef HAVE_X11
@@ -765,7 +766,7 @@ void ScanPopup::translateInputFinished()
 
 void ScanPopup::showTranslationFor( QString const & inputWord )
 {
-  ui.pronounceButton->hide();
+  audioPlayerUi->setPlayable( false );
 
   unsigned groupId = ui.groupList->getCurrentGroup();
   definition->showDefinition( inputWord, groupId );
@@ -1099,7 +1100,7 @@ void ScanPopup::altModePoll()
 
 void ScanPopup::pageLoaded( ArticleView * )
 {
-  ui.pronounceButton->setVisible( definition->hasSound() );
+  audioPlayerUi->setPlayable( definition->hasSound() );
 
   updateBackForwardButtons();
 

--- a/scanpopup.cc
+++ b/scanpopup.cc
@@ -140,6 +140,7 @@ ScanPopup::ScanPopup( QWidget * parent,
   connect( ui.translateBox->wordList(), SIGNAL( statusBarMessage( QString const &, int, QPixmap const & ) ),
            this, SLOT( showStatusBarMessage( QString const &, int, QPixmap const & ) ) );
 
+  ui.pronounceButton->setToolTip( pronounceActionText( AudioPlayerInterface::StoppedState ) );
   audioPlayerUi.reset( new AudioPlayerUi< QToolButton >( *ui.pronounceButton, &QToolButton::setVisible ) );
   audioPlayerUi->setPlayable( false );
 
@@ -483,6 +484,7 @@ void ScanPopup::translateWord( QString const & word )
 void ScanPopup::setPlaybackState( AudioPlayerInterface::State state )
 {
   audioPlayerUi->setPlaybackState( state );
+  ui.pronounceButton->setToolTip( pronounceActionText( state ) );
 }
 
 #ifdef HAVE_X11

--- a/scanpopup.cc
+++ b/scanpopup.cc
@@ -1026,7 +1026,10 @@ void ScanPopup::prefixMatchFinished()
 void ScanPopup::on_pronounceButton_clicked( bool checked )
 {
   if( checked )
-    definition->playSound();
+  {
+    if( !definition->playSound() ) // This pronunciation request failed before reaching the audio player.
+      ui.pronounceButton->setChecked( false ); // This is the only opportunity to fix the checked state.
+  }
   else
     definition->stopPlayback();
 }

--- a/scanpopup.hh
+++ b/scanpopup.hh
@@ -145,6 +145,7 @@ private:
   DictionaryBar dictionaryBar;
   MainStatusBar * mainStatusBar;
   QScopedPointer< AudioPlayerUi< QToolButton > > audioPlayerUi;
+  PronounceActionTexts pronounceActionTexts;
   /// Fonts saved before words zooming is in effect, so it could be reset back.
   QFont wordListDefaultFont, translateLineDefaultFont;
 

--- a/scanpopup.hh
+++ b/scanpopup.hh
@@ -6,11 +6,14 @@
 
 #include "article_netmgr.hh"
 #include "audioplayerinterface.hh"
+#include "audioplayerui.hh"
 #include "articleview.hh"
 #include "wordfinder.hh"
 #include "keyboardstate.hh"
 #include "config.hh"
 #include "ui_scanpopup.h"
+#include <QScopedPointer>
+#include <QToolButton>
 #include <QDialog>
 #include <QClipboard>
 #include "history.hh"
@@ -141,6 +144,7 @@ private:
   Config::Events configEvents;
   DictionaryBar dictionaryBar;
   MainStatusBar * mainStatusBar;
+  QScopedPointer< AudioPlayerUi< QToolButton > > audioPlayerUi;
   /// Fonts saved before words zooming is in effect, so it could be reset back.
   QFont wordListDefaultFont, translateLineDefaultFont;
 

--- a/scanpopup.hh
+++ b/scanpopup.hh
@@ -5,6 +5,7 @@
 #define __SCANPOPUP_HH_INCLUDED__
 
 #include "article_netmgr.hh"
+#include "audioplayerinterface.hh"
 #include "articleview.hh"
 #include "wordfinder.hh"
 #include "keyboardstate.hh"
@@ -49,6 +50,8 @@ public:
   void applyWordsZoomLevel();
   /// Translate the word
   void translateWord( QString const & word );
+
+  void setPlaybackState( AudioPlayerInterface::State state );
 
   void setDictionaryIconSize();
 
@@ -191,7 +194,7 @@ private slots:
   void mouseHovered( QString const & , bool forcePopup);
   void currentGroupChanged( QString const & );
   void prefixMatchFinished();
-  void on_pronounceButton_clicked();
+  void on_pronounceButton_clicked( bool checked );
   void pinButtonClicked( bool checked );
   void on_showDictionaryBar_clicked( bool checked );
   void showStatusBarMessage ( QString const &, int, QPixmap const & );

--- a/scanpopup.ui
+++ b/scanpopup.ui
@@ -150,6 +150,9 @@
              <property name="shortcut">
               <string>Alt+S</string>
              </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
              <property name="autoRaise">
               <bool>false</bool>
              </property>

--- a/scanpopup.ui
+++ b/scanpopup.ui
@@ -137,9 +137,6 @@
            </item>
            <item>
             <widget class="QToolButton" name="pronounceButton">
-             <property name="toolTip">
-              <string>Pronounce Word (Alt+S)</string>
-             </property>
              <property name="text">
               <string>...</string>
              </property>


### PR DESCRIPTION
This pull request provides a way to stop a long "pronunciation" with a button click or Alt+S shortcut. Such long "pronunciations" are common in Wikipedia - musical compositions, spoken articles, etc. They can be triggered inadvertently or automatically when "Auto-pronounce words ..." options are enabled. See individual commit messages for more details.

I'm not sure if changing the pronounce buttons' tooltip back and forth is worth the amount of code in the [third](https://github.com/goldendict/goldendict/commit/c8be118b3a9fbb447152373e0052d2e24e032a07) and [fourth](https://github.com/goldendict/goldendict/commit/a4721ee093e0a185a84d64774fce5f0cfd6404c9) commits. These two commits are optional and can be removed.

The pronounce button checked state can temporarily get out of sync with the actual audio playback state in case of asynchronous resource downloading errors, as described in the [fifth commit message](https://github.com/goldendict/goldendict/commit/44ceda64d9571c415fc04ba9cb74c82841fbf201). I don't think that this is a critical issue. The situation can be improved by merging my other pull request #972. See the [merge commit message](https://github.com/vedgy/goldendict/commit/3209b4093e5877e7202dde96c18d308c938c811e) in https://github.com/vedgy/goldendict/tree/wip-pronounce-stop-if-playing-and-from-next-dictionary for details \[this is a separate branch that merges my *pronounce-button-stop-if-playing* branch (on which this pull request is based) and my *wip-auto-pronounce-from-next-dictionary* branch (on which #972 is based)\].

There are 3 old `audioPlayer->stop();` calls in `ArticleView` member functions. They were briefly discussed in comments to #983. With the changes in this pull request there is a universal reliable way to stop audio playback, so there seems to be little reason to stop it before showing Dictionaries or Preferences windows (this *might* be marginally useful to avoid long annoying "pronunciation", which can't be stopped while one of these modal windows is open). Stopping playback before loading a new article has some benefit though: it can reduce the delay before the next pronunciation starts, because some audio player implementations may take several hundred milliseconds to stop. This delay reducing is not consistent however: clicking a *Back* or *Forward* navigation button does not stop current playback. Overall it is not clear to me whether these stop function calls should be removed or not. Perhaps they should *if* there is a common use case, for which stopping playback in these situations is undesirable.