### PR TITLE
Add a shortcut to focus scan popup's article view

### DIFF
--- a/articleview.hh
+++ b/articleview.hh
@@ -136,11 +136,11 @@ public slots:
   /// Goes forward in history
   void forward();
 
-public:
-
   /// Takes the focus to the view
   void focus()
   { ui.definition->setFocus( Qt::ShortcutFocusReason ); }
+
+public:
 
   /// Reloads the view
   void reload()

--- a/scanpopup.cc
+++ b/scanpopup.cc
@@ -229,6 +229,11 @@ ScanPopup::ScanPopup( QWidget * parent,
   connect( &focusTranslateLineAction, SIGNAL( triggered() ),
            this, SLOT( focusTranslateLine() ) );
 
+  QAction * const focusArticleViewAction = new QAction( this );
+  focusArticleViewAction->setShortcutContext( Qt::WidgetWithChildrenShortcut );
+  focusArticleViewAction->setShortcut( QKeySequence( "Ctrl+N" ) );
+  addAction( focusArticleViewAction );
+  connect( focusArticleViewAction, SIGNAL( triggered() ), definition, SLOT( focus() ) );
 
   switchExpandModeAction.setShortcuts( QList< QKeySequence >() <<
                                        QKeySequence( Qt::CTRL + Qt::Key_8 ) <<


### PR DESCRIPTION
The article view focus is necessary to navigate a word definition via
keyboard rather than mouse. The shortcut - Ctrl+N - is the same as
the one in the main window for the corresponding action.