### PR TITLE
Safety menu sequence in dictionaries order window

### DIFF
--- a/orderandprops.cc
+++ b/orderandprops.cc
@@ -252,13 +252,8 @@ void OrderAndProps::describeDictionary( DictListWidget * lst, QModelIndex const 
 void OrderAndProps::contextMenuRequested( const QPoint & pos )
 {
   QMenu menu( this );
-  QAction * sortNameAction = new QAction( tr( "Sort by name" ), &menu );
-  menu.addAction( sortNameAction );
-  QAction * sortLangAction = new QAction( tr( "Sort by languages" ), &menu );
-  menu.addAction( sortLangAction );
 
   QAction * showHeadwordsAction = NULL;
-
   QModelIndex idx = ui.searchLine->mapToSource( ui.dictionaryOrder->indexAt( pos ) );
   sptr< Dictionary::Class > dict;
   if( idx.isValid() && (unsigned)idx.row() < ui.dictionaryOrder->getCurrentDictionaries().size() )
@@ -268,6 +263,11 @@ void OrderAndProps::contextMenuRequested( const QPoint & pos )
     showHeadwordsAction = new QAction( tr( "Dictionary headwords" ), &menu );
     menu.addAction( showHeadwordsAction );
   }
+
+  QAction * sortNameAction = new QAction( tr( "Sort by name" ), &menu );
+  menu.addAction( sortNameAction );
+  QAction * sortLangAction = new QAction( tr( "Sort by languages" ), &menu );
+  menu.addAction( sortLangAction );
 
   QAction * result = menu.exec( ui.dictionaryOrder->mapToGlobal( pos ) );
 


### PR DESCRIPTION
On accidentally mouse moving in the same time, when right button is clicking, first context menu stroke may be apply. If this stroke is dictionaries reordering, it may be not noticed (especially, when filter is enabled), and after the windows OK button click ALL dictionaries will be reordered!
This commit places on context menu first stroke safety "Dictionary headwords".