### PR TITLE
Use filePath instead of CanonicalPath

### DIFF
--- a/loaddictionaries.cc
+++ b/loaddictionaries.cc
@@ -117,7 +117,7 @@ void LoadDictionaries::handlePath( Config::Path const & path )
   for( QFileInfoList::const_iterator i = entries.constBegin();
        i != entries.constEnd(); ++i )
   {
-    QString fullName = i->canonicalFilePath();
+    QString fullName = i->absoluteFilePath();
 
     if ( path.recursive && i->isDir() )
     {


### PR DESCRIPTION
handle symlink dict file properly.
previous way (CanonicalPath) will dereference the symlink, thus cause
the following problems.
e.g. the directory structure is
```
  a/a.mdx -> ../1.mdx    # the main file of a '.mdx' dict
  a/a.mdd -> ../2.mdd
  a/a.css -> ../3.css    # the css filename 'a.css' is hard-coded in '1.mdx'
  1.mdx
  2.mdd
  3.css
```
If you follow the symlink when openning dict `a/a.mdx`, goldendict will read `1.mdx`. But, it will fail to
find the corresponding `1.mdd` and the hard-coded `a.css`.

I encountered such problem when using git-annex to manage dict files. git-annex will move dict files to `.git/annex/objects/${hash of the file}` and replace the original file with symlink. I found that the symlink dereference of goldendict will break the relative directory structure stored in the '.mdx' file.