### PR TITLE
use https for the submodule as the git protocol is completely unsecure and easily susceptible to MITM attacks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "winlibs/lib/msvc"]
 	path = winlibs/lib/msvc
-	url = git://github.com/Tvangeste/goldendict-winlibs-prebuilt.git
+	url = https://github.com/Tvangeste/goldendict-winlibs-prebuilt.git


### PR DESCRIPTION
use https for the submodule as the git protocol is completely unsecure and easily susceptible to MITM attacks