### PR TITLE
Utf8: don't use empty vector for string encode (issue #1076)

### DIFF
--- a/utf8.cc
+++ b/utf8.cc
@@ -133,6 +133,9 @@ long decode( char const * in_, size_t inSize, wchar * out_ )
 
 string encode( wstring const & in ) throw()
 {
+  if ( in.size() == 0 )
+    return "";
+
   std::vector< char > buffer( in.size() * 4 );
 
   return string( &buffer.front(),


### PR DESCRIPTION
Fix for #1076