### PR TITLE
Avoid duplicate currentGroupChanged() connection

### DIFF
--- a/scanpopup.cc
+++ b/scanpopup.cc
@@ -117,9 +117,6 @@ ScanPopup::ScanPopup( QWidget * parent,
   translateLineDefaultFont = ui.translateBox->font();
   groupListDefaultFont = ui.groupList->font();
 
-  applyZoomFactor();
-  applyWordsZoomLevel();
-
   ui.mainLayout->addWidget( definition );
 
   ui.translateBox->wordList()->attachFinder( &wordFinder );
@@ -331,6 +328,9 @@ ScanPopup::ScanPopup( QWidget * parent,
   connect( &delayTimer, SIGNAL( timeout() ),
     this, SLOT( delayShow() ) );
 #endif
+
+  applyZoomFactor();
+  applyWordsZoomLevel();
 }
 
 ScanPopup::~ScanPopup()


### PR DESCRIPTION
Before this change ScanPopup::applyWordsZoomLevel() was called before
the primary connection to ScanPopup::currentGroupChanged() in
ScanPopup's constructor. This meant that disconnect() had no effect and
connect() established the first connection during the first call to
ScanPopup::applyWordsZoomLevel(). This caused 2 issues:
  1. Since the connection happened before the filling of ui.groupList
in ScanPopup's constructor, the current group in scan popup was always
"All" on Goldendict start.
  2. Since the connection was not unique, the slot was connected twice
to the same signal, and it was actually called twice.

The bug was introduced in 92e8c85eeca078a65c6fd4409b1ebd2832fbb55f.