### PR TITLE
Undef common words defined in X11 headers

### DIFF
--- a/hotkeywrapper.hh
+++ b/hotkeywrapper.hh
@@ -12,9 +12,9 @@
 #include <QX11Info>
 #include <X11/Xlibint.h>
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #undef Bool
-#endif
+#undef min
+#undef max
 
 #endif
 

--- a/main.cc
+++ b/main.cc
@@ -9,6 +9,9 @@
 
 #include "processwrapper.hh"
 #include "hotkeywrapper.hh"
+#ifdef HAVE_X11
+#include <fixx11h.h>
+#endif
 
 //#define __DO_DEBUG
 

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -66,6 +66,7 @@
 #ifdef HAVE_X11
 #include <QX11Info>
 #include <X11/Xlib.h>
+#include <fixx11h.h>
 #endif
 
 #define MIN_THREAD_COUNT 4

--- a/mainwindow.hh
+++ b/mainwindow.hh
@@ -23,7 +23,6 @@
 #include "wordfinder.hh"
 #include "dictionarybar.hh"
 #include "history.hh"
-#include "hotkeywrapper.hh"
 #include "mainstatusbar.hh"
 #include "mruqmenu.hh"
 #include "translatebox.hh"
@@ -32,6 +31,7 @@
 #include "fulltextsearch.hh"
 #include "helpwindow.hh"
 
+#include "hotkeywrapper.hh"
 #ifdef HAVE_X11
 #include <fixx11h.h>
 #endif


### PR DESCRIPTION
* #undef Bool with Qt4 as well as with Qt5.
* #undef min, #undef max from <X11/Xlibint.h>.
* #include <fixx11h.h> just after hotkeywrapper.hh. Unfortunately this
  header can not be included in hotkeywrapper.hh directly because
  some of the undef-ed words are actually used in hotkeywrapper.cc.
* #include <fixx11h.h> after <X11/Xlib.h> in mainwindow.cc just in case
  hotkeywrapper.hh stops including this Xlib.h header in the future.

These changes should make future compilation errors less likely.

For example, without "#undef min" in hotkeywrapper.hh, including
<iomanip> in mainwindow.cc after the mainwindow.hh include resulted in
the following GCC 8 compilation error:
 /usr/include/c++/8.2.1/bits/locale_facets_nonio.tcc:945:22:
  error: expected unqualified-id before ‘(’ token
      __minlen = std::min(__minlen,
                      ^~~