### PR TITLE
Add an option to avoid auto-scrolling out of top dictionary

### DIFF
--- a/articleview.cc
+++ b/articleview.cc
@@ -369,7 +369,7 @@ void ArticleView::showDefinition( QString const & word, unsigned group,
   if( cfg.preferences.ignoreDiacritics )
     Qt4x5::Url::addQueryItem( req, "ignore_diacritics", "1" );
 
-  if ( scrollTo.size() )
+  if( !cfg.preferences.avoidAutoScrolling && !scrollTo.isEmpty() )
     Qt4x5::Url::addQueryItem( req, "scrollto", scrollTo );
 
   Contexts::Iterator pos = contexts.find( "gdanchor" );

--- a/config.cc
+++ b/config.cc
@@ -152,6 +152,7 @@ Preferences::Preferences():
   autoStart( false ),
   doubleClickTranslates( true ),
   selectWordBySingleClick( false ),
+  avoidAutoScrolling( false ),
   escKeyHidesMainWindow( false ),
   alwaysOnTop ( false ),
   searchInDock ( false ),
@@ -794,6 +795,9 @@ Class load() THROW_SPEC( exError )
 
     if ( !preferences.namedItem( "selectWordBySingleClick" ).isNull() )
       c.preferences.selectWordBySingleClick = ( preferences.namedItem( "selectWordBySingleClick" ).toElement().text() == "1" );
+
+    if ( !preferences.namedItem( "avoidAutoScrolling" ).isNull() )
+      c.preferences.avoidAutoScrolling = ( preferences.namedItem( "avoidAutoScrolling" ).toElement().text() == "1" );
 
     if ( !preferences.namedItem( "escKeyHidesMainWindow" ).isNull() )
       c.preferences.escKeyHidesMainWindow = ( preferences.namedItem( "escKeyHidesMainWindow" ).toElement().text() == "1" );
@@ -1642,6 +1646,10 @@ void save( Class const & c ) THROW_SPEC( exError )
 
     opt = dd.createElement( "selectWordBySingleClick" );
     opt.appendChild( dd.createTextNode( c.preferences.selectWordBySingleClick ? "1":"0" ) );
+    preferences.appendChild( opt );
+
+    opt = dd.createElement( "avoidAutoScrolling" );
+    opt.appendChild( dd.createTextNode( c.preferences.avoidAutoScrolling ? "1":"0" ) );
     preferences.appendChild( opt );
 
     opt = dd.createElement( "escKeyHidesMainWindow" );

--- a/config.hh
+++ b/config.hh
@@ -260,6 +260,7 @@ struct Preferences
   bool autoStart;
   bool doubleClickTranslates;
   bool selectWordBySingleClick;
+  bool avoidAutoScrolling;
   bool escKeyHidesMainWindow;
   bool alwaysOnTop;
 

--- a/preferences.cc
+++ b/preferences.cc
@@ -163,6 +163,7 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
   ui.cbAutostart->setChecked( p.autoStart );
   ui.doubleClickTranslates->setChecked( p.doubleClickTranslates );
   ui.selectBySingleClick->setChecked( p.selectWordBySingleClick);
+  ui.avoidAutoScrolling->setChecked( p.avoidAutoScrolling );
   ui.escKeyHidesMainWindow->setChecked( p.escKeyHidesMainWindow );
 
   ui.enableMainWindowHotkey->setChecked( p.enableMainWindowHotkey );
@@ -373,6 +374,7 @@ Config::Preferences Preferences::getPreferences()
   p.autoStart = ui.cbAutostart->isChecked();
   p.doubleClickTranslates = ui.doubleClickTranslates->isChecked();
   p.selectWordBySingleClick = ui.selectBySingleClick->isChecked();
+  p.avoidAutoScrolling = ui.avoidAutoScrolling->isChecked();
   p.escKeyHidesMainWindow = ui.escKeyHidesMainWindow->isChecked();
 
   p.enableMainWindowHotkey = ui.enableMainWindowHotkey->isChecked();

--- a/preferences.ui
+++ b/preferences.ui
@@ -369,6 +369,18 @@ be the last ones.</string>
          </item>
         </layout>
        </item>
+       <item row="4" column="1">
+        <widget class="QCheckBox" name="avoidAutoScrolling">
+         <property name="toolTip">
+          <string>Normally, clicking a link or looking up selection in an article
+loads the translation and scrolls to the article from the same dictionary.
+With this on however, the article from the topmost dictionary is shown.</string>
+         </property>
+         <property name="text">
+          <string>Avoid auto-scrolling out of top dictionary</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="tab_4">


### PR DESCRIPTION
When a user clicks a link in a dictionary or requests translation of
a word by double-clicking or translates selection via the context menu,
the definition in all dictionaries is displayed. Then the article from
the dictionary, out of which the translation was requested, becomes
current and the view scrolls down to this article placing it on top,
hiding translations from dictionaries above it.

This behavior is inconvenient in some workflows and forces the user to
manually navigate to the top dictionary translation each time this
auto-scrolling happens.

For example: a user has English->Russian dictionaries and
English->English dictionaries. The English->Russian dictionaries are
higher up in the dictionary order because they provide easier/faster to
understand translations. Some rare words and phrases are missing from
the English->Russian dictionaries however. So the user has to read the
English explanation of the word/phrase. When the user double-clicks a
word or follows a link in the English->English dictionary article, she
would rather see translations from the preferable English->Russian
dictionaries.

The new option allows to disable auto-scrolling and ensure that articles
from higher-priority dictionaries are visible. The option doesn't affect
backward/forward navigation via arrow buttons or Alt+Arrow shortcuts:
these still scroll to the stored vertical position among articles. This
remaining auto-scrolling is not a problem for the described use case and
hopefully for other potential use cases.