### PR TITLE
Restore dictionary toolbar handle in Modern style

### DIFF
--- a/qt-style-st-modern.css
+++ b/qt-style-st-modern.css
@@ -25,7 +25,7 @@ MainWindow #historyPane #historyList, MainWindow #favoritesPane #favoritesTree
 }
 
 /* remove the main toolbar handle */
-#navToolbar::handle, #dictionaryBar::handle {
+#navToolbar::handle, #dictionaryBarXX::handle {
   image: none;
   width:  0px;
   margin-left: 1px;


### PR DESCRIPTION
Moving dictionaryBar with invisible handle is possible but difficult and
practically undiscoverable.
I can think of two reasons a user might want to move this toolbar:
  * increase the width of translate line to the user's liking;
  * move dictionary bar to a vertical position like in scan popup.

If a user applies her own tweaks on top of standard Modern style in
user-defined qt-style.css, it is more obvious how to hide this handle
than how to restore it when it is already hidden by the built-in style.