### PR TITLE
 Add --words-zoom-level and --zoom-factor command line options

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -2,6 +2,7 @@
  * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
 
 #include <stdio.h>
+#include <limits>
 #include <QIcon>
 #include "gdappstyle.hh"
 #include "mainwindow.hh"
@@ -112,7 +113,12 @@ void gdMessageHandler( QtMsgType type, const char *msg_ )
 
 class GDCommandLine
 {
+  static int invalidWordsZoomLevel() { return std::numeric_limits< int >::max(); }
+  static double invalidZoomFactor() { return std::numeric_limits< double >::max(); }
+
   bool crashReport, logFile;
+  int wordsZoomLevel;
+  double zoomFactor;
   QString word, groupName, popupGroupName, errFileName;
   QVector< QString > arguments;
 public:
@@ -123,6 +129,11 @@ public:
 
   inline QString errorFileName()
   { return errFileName; }
+
+  bool needSetWordsZoomLevel() const { return wordsZoomLevel != invalidWordsZoomLevel(); }
+  int getWordsZoomLevel() const { return wordsZoomLevel; }
+  bool needSetZoomFactor() const { return zoomFactor != invalidZoomFactor(); }
+  double getZoomFactor() const { return zoomFactor; }
 
   inline bool needSetGroup()
   { return !groupName.isEmpty(); }
@@ -148,7 +159,9 @@ public:
 
 GDCommandLine::GDCommandLine( int argc, char **argv ):
 crashReport( false ),
-logFile( false )
+logFile( false ),
+wordsZoomLevel( invalidWordsZoomLevel() ),
+zoomFactor( invalidZoomFactor() )
 {
   if( argc > 1 )
   {
@@ -181,6 +194,18 @@ logFile( false )
       if( arguments[ i ].compare( "--log-to-file" ) == 0 )
       {
         logFile = true;
+        continue;
+      }
+      else
+      if( arguments[ i ].startsWith( "--words-zoom-level=" ) )
+      {
+        wordsZoomLevel = arguments[ i ].mid( arguments[ i ].indexOf( '=' ) + 1 ).toInt();
+        continue;
+      }
+      else
+      if( arguments[ i ].startsWith( "--zoom-factor=" ) )
+      {
+        zoomFactor = arguments[ i ].mid( arguments[ i ].indexOf( '=' ) + 1 ).toDouble();
         continue;
       }
       else
@@ -293,6 +318,17 @@ int main( int argc, char ** argv )
   if ( app.isRunning() )
   {
     bool wasMessage = false;
+
+    if( gdcl.needSetWordsZoomLevel() )
+    {
+      app.sendMessage( "setWordsZoomLevel: " + QString::number( gdcl.getWordsZoomLevel() ) );
+      wasMessage = true;
+    }
+    if( gdcl.needSetZoomFactor() )
+    {
+      app.sendMessage( "setZoomFactor: " + QString::number( gdcl.getZoomFactor() ) );
+      wasMessage = true;
+    }
 
     if( gdcl.needSetGroup() )
     {
@@ -433,6 +469,11 @@ int main( int argc, char ** argv )
 
   QObject::connect( &app, SIGNAL(messageReceived(const QString&)),
     &m, SLOT(messageFromAnotherInstanceReceived(const QString&)));
+
+  if( gdcl.needSetWordsZoomLevel() )
+    m.setWordsZoomLevel( gdcl.getWordsZoomLevel() );
+  if( gdcl.needSetZoomFactor() )
+    m.setZoomFactorImmediately( gdcl.getZoomFactor() );
 
   if( gdcl.needSetGroup() )
     m.setGroupByName( gdcl.getGroupName(), true );

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -3597,22 +3597,36 @@ void MainWindow::on_alwaysOnTop_triggered( bool checked )
     installHotKeys();
 }
 
+void MainWindow::setZoomFactorImmediately( double factor )
+{
+  if ( cfg.preferences.zoomFactor == factor )
+    return;
+  cfg.preferences.zoomFactor = factor;
+  adjustCurrentZoomFactor();
+  scaleArticlesByCurrentZoomFactor();
+}
+
+void MainWindow::setZoomFactor( double factor )
+{
+  if ( cfg.preferences.zoomFactor == factor )
+    return;
+  cfg.preferences.zoomFactor = factor;
+  applyZoomFactor();
+}
+
 void MainWindow::zoomin()
 {
-  cfg.preferences.zoomFactor += 0.1;
-  applyZoomFactor();
+  setZoomFactor( cfg.preferences.zoomFactor + 0.1 );
 }
 
 void MainWindow::zoomout()
 {
-  cfg.preferences.zoomFactor -= 0.1;
-  applyZoomFactor();
+  setZoomFactor( cfg.preferences.zoomFactor - 0.1 );
 }
 
 void MainWindow::unzoom()
 {
-  cfg.preferences.zoomFactor = 1;
-  applyZoomFactor();
+  setZoomFactor( 1 );
 }
 
 void MainWindow::applyZoomFactor()
@@ -3666,25 +3680,27 @@ void MainWindow::scaleArticlesByCurrentZoomFactor()
     scanPopup->applyZoomFactor();
 }
 
+void MainWindow::setWordsZoomLevel( int level )
+{
+  if ( cfg.preferences.wordsZoomLevel == level )
+    return;
+  cfg.preferences.wordsZoomLevel = level;
+  applyWordsZoomLevel();
+}
+
 void MainWindow::doWordsZoomIn()
 {
-  ++cfg.preferences.wordsZoomLevel;
-
-  applyWordsZoomLevel();
+  setWordsZoomLevel( cfg.preferences.wordsZoomLevel + 1 );
 }
 
 void MainWindow::doWordsZoomOut()
 {
-  --cfg.preferences.wordsZoomLevel;
-
-  applyWordsZoomLevel();
+  setWordsZoomLevel( cfg.preferences.wordsZoomLevel - 1 );
 }
 
 void MainWindow::doWordsZoomBase()
 {
-  cfg.preferences.wordsZoomLevel = 0;
-
-  applyWordsZoomLevel();
+  setWordsZoomLevel( 0 );
 }
 
 void MainWindow::applyWordsZoomLevel()
@@ -3763,6 +3779,16 @@ void MainWindow::messageFromAnotherInstanceReceived( QString const & message )
   if ( message == "bringToFront" )
   {
     toggleMainWindow( true );
+    return;
+  }
+  if( message.leftRef( 19 ) == "setWordsZoomLevel: " )
+  {
+    setWordsZoomLevel( message.mid( 19 ).toInt() );
+    return;
+  }
+  if( message.leftRef( 15 ) == "setZoomFactor: " )
+  {
+    setZoomFactor( message.mid( 15 ).toDouble() );
     return;
   }
   if( message.left( 15 ) == "translateWord: " )

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -805,7 +805,6 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   // Update zoomers
   adjustCurrentZoomFactor();
   scaleArticlesByCurrentZoomFactor();
-  applyWordsZoomLevel();
 
   // Update autostart info
   setAutostart(cfg.preferences.autoStart);

--- a/mainwindow.hh
+++ b/mainwindow.hh
@@ -75,6 +75,9 @@ public:
   QString getTranslateLineText() const
   { return translateLine->text(); }
 
+  void setZoomFactorImmediately( double factor );
+  void setWordsZoomLevel( int level );
+
   /// Set group for main/popup window
   void setGroupByName( QString const & name, bool main_window );
 
@@ -234,6 +237,7 @@ private:
   /// Creates hotkeyWrapper and hooks the currently set keys for it
   void installHotKeys();
 
+  void setZoomFactor( double factor );
   void applyZoomFactor();
   void adjustCurrentZoomFactor();
 


### PR DESCRIPTION
These options allow to configure zooming on application start.

Also these options allow to assign global keyboard shortcuts that set
zoom level and factor to predefined values for the already running
goldendict instance in system preferences.

For example, a user can set up several zooming presets for different
activities and switch between them via global keyboard shortcuts.