### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/bgl_babylon.cc
+++ b/bgl_babylon.cc
@@ -41,6 +41,7 @@
 #include <io.h>
 #define DUP _dup
 #else
+#include <unistd.h>
 #define DUP dup
 #endif
 

--- a/goldendict.pro
+++ b/goldendict.pro
@@ -191,6 +191,9 @@ unix:!mac {
     helps.files = help/*.qch
     INSTALLS += helps
 }
+freebsd {
+    LIBS += -liconv -lexecinfo
+}
 mac {
     TARGET = GoldenDict
     # Uncomment this line to make a universal binary.


### PR DESCRIPTION
Add missing #include for dup() function (see http://pubs.opengroup.org/onlinepubs/9699919799/functions/dup.html, dup requires unistd.h).

Add linker flags for FreeBSD (iconv and backtrace).