### PR TITLE
Change pinned scan popup flags from Qt::Dialog to Qt::Window

### DIFF
--- a/scanpopup.cc
+++ b/scanpopup.cc
@@ -33,6 +33,17 @@ Qt::Popup
 #endif
 ;
 
+static const Qt::WindowFlags pinnedWindowFlags =
+#ifdef HAVE_X11
+/// With the Qt::Dialog flag, scan popup is always on top of the main window
+/// on Linux/X11 with Qt 4, Qt 5 since version 5.12.1 (QTBUG-74309).
+/// Qt::Window allows to use the scan popup and the main window independently.
+Qt::Window
+#else
+Qt::Dialog
+#endif
+;
+
 #ifdef HAVE_X11
 static bool ownsClipboardMode( QClipboard::Mode mode )
 {
@@ -186,7 +197,7 @@ ScanPopup::ScanPopup( QWidget * parent,
   if ( cfg.pinPopupWindow )
   {
     dictionaryBar.setMovable( true );
-    Qt::WindowFlags flags = Qt::Dialog;
+    Qt::WindowFlags flags = pinnedWindowFlags;
     if( cfg.popupWindowAlwaysOnTop )
       flags |= Qt::WindowStaysOnTopHint;
     setWindowFlags( flags );
@@ -1063,7 +1074,7 @@ void ScanPopup::pinButtonClicked( bool checked )
     uninterceptMouse();
 
     ui.onTopButton->setVisible( true );
-    Qt::WindowFlags flags = Qt::Dialog;
+    Qt::WindowFlags flags = pinnedWindowFlags;
     if( ui.onTopButton->isChecked() )
       flags |= Qt::WindowStaysOnTopHint;
     setWindowFlags( flags );


### PR DESCRIPTION
There is a regression since Qt 5.12.1 that forces the pinned scan popup
window to be always on top of the main window on Linux/X11 because of
its Qt::Dialog window flag. The same issue is present in Qt 4.
The Qt regression is reported as QTBUG-74309, but chances of it being
fixed any time soon seem slim.

ScanPopup's Qt::Dialog flag looks like a mistake:
  1. This flag was used initially, when ScanPopup inherited QDialog -
added in 2be1c2b3750fd2269e52379441c9c3a10b18a693.
  2. When ScanPopup's parent class was changed from QDialog to
QMainWindow in a0fda4383a9d62d0ef14805de48d77864de29181, the Qt::Dialog
was not changed to QMainWindow's default Qt::Window. This appears to be
an oversight.

The documentation for Qt::Dialog window flag states that it causes a
window to be decorated as a dialog (typically no maximize or minimize
buttons in the title bar). I suppose adding these buttons to
the scan popup's title bar is not an issue.

As a bonus, the Qt::Dialog flag prevented scan popup window tiling when
moving toward the screen edge in Xfce. It works perfectly now.