### PR TITLE
Don't construct scan popup twice at startup

### DIFF
--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -1253,7 +1253,8 @@ void MainWindow::applyWebSettings()
 
 void MainWindow::makeDictionaries()
 {
-  scanPopup.reset();
+  Q_ASSERT( !scanPopup && "Scan popup must not exist while dictionaries are initialized. "
+                          "It does not support dictionaries changes and must be constructed anew." );
 
   wordFinder.clear();
 
@@ -1275,7 +1276,6 @@ void MainWindow::makeDictionaries()
 
   updateStatusLine();
   updateGroupList();
-  makeScanPopup();
 }
 
 void MainWindow::updateStatusLine()


### PR DESCRIPTION
abcabb77fac6e52fdddc2152cc274e98c4a81d8a added a makeScanPopup() call
after applyQtStyleSheet() in MainWindow constructor to apply Qt style
sheets to the scan popup. This call destroys the scan popup created
earlier in the MainWindow constructor and creates a new instance.

Let us remove the first, now redundant invocation of makeScanPopup()
from MainWindow::makeDictionaries() to improve startup performance.
makeDictionaries() is currently called only once, so modifying it is not
a problem. If makeDictionaries() is used elsewhere in the future,
the added assertion will remind to reconstruct the scan popup.