### PR TITLE
Fix empty menu if program compiled with qt5

### DIFF
--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -585,8 +585,11 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   connect( ui.menuHistory, SIGNAL( aboutToShow() ),
            this, SLOT( updateHistoryMenu() ) );
 
+#if !defined( HAVE_X11 ) || QT_VERSION < QT_VERSION_CHECK( 5, 0, 0 )
   // Show tray icon early so the user would be happy. It won't be functional
   // though until the program inits fully.
+  // Do not create dummy tray icon in X. Cause QT5 failed to upgrade systemtray context menu.
+  // And as result menu for some DEs apppear to be empty, for example in MATE DE.
 
   if ( cfg.preferences.enableTrayIcon )
   {
@@ -594,6 +597,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
     trayIcon->setToolTip( tr( "Loading..." ) );
     trayIcon->show();
   }
+#endif
 
   connect( navBack, SIGNAL( triggered() ),
            this, SLOT( backClicked() ) );


### PR DESCRIPTION
Related issue https://github.com/goldendict/goldendict/issues/1155
Fixed by removing old dummy system tray and creating new one which
actually accepts setcontextmenu. so loading system tray still will be
shown to user.
Tested for:
Mate 1.22.1
XFCE4 4.12
KDE 5.14.5 (damn it's so ugly now I mean kde)
tried Gnome but feel myself like win10 user, no system tray there :)