### PR TITLE
Remove an unused Qt5 dependency from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This code has been run and tested on Windows XP/Vista/7, Ubuntu Linux, Mac OS X.
 
     sudo apt-get install git pkg-config build-essential qt5-qmake \
          libvorbis-dev zlib1g-dev libhunspell-dev x11proto-record-dev \
-         qtdeclarative5-dev libqtwebkit-dev libxtst-dev liblzo2-dev libbz2-dev \
+         qtdeclarative5-dev libxtst-dev liblzo2-dev libbz2-dev \
          libao-dev libavutil-dev libavformat-dev libtiff5-dev libeb16-dev \
          libqt5webkit5-dev libqt5svg5-dev libqt5x11extras5-dev qttools5-dev \
          qttools5-dev-tools qtmultimedia5-dev libqt5multimedia5-plugins


### PR DESCRIPTION
[libqtwebkit-dev](https://packages.ubuntu.com/bionic/amd64/libqtwebkit-dev/filelist) contains the development files of Qt4 QtWebKit library.
Installing this package pulls many Qt4 dependencies. Neither this
package nor its dependencies are needed to build a Qt5 version of
goldendict. I have successfully built a Qt5 version of goldendict
on a fresh KDE neon system without installing this package.
Note that the development files of Qt5 QtWebKit library are inside the
[libqt5webkit5-dev](https://packages.ubuntu.com/bionic/amd64/libqt5webkit5-dev/filelist) package, which is duly listed as a Qt5 goldendict
dependency.