### PR TITLE
Forvo api calls via https

### DIFF
--- a/forvo.cc
+++ b/forvo.cc
@@ -168,7 +168,7 @@ void ForvoArticleRequest::addQuery( QNetworkAccessManager & mgr,
     key = apiKey;
 
   QUrl reqUrl = QUrl::fromEncoded(
-      QString( "http://apifree.forvo.com"
+      QString( "https://apifree.forvo.com"
                "/key/" + key +
                "/action/word-pronunciations"
                "/format/xml"


### PR DESCRIPTION
About a month ago I started getting errors when using forvo. Like in issue #1222.
I didn't understand what happened but switching to https helped.