### PR TITLE
appdata.xml: Pass appstream-util validation

### DIFF
--- a/redist/goldendict.appdata.xml
+++ b/redist/goldendict.appdata.xml
@@ -34,4 +34,6 @@
   </screenshots>
   <url type="homepage">http://goldendict.org</url>
   <update_contact>https://github.com/goldendict/goldendict</update_contact>
+  <launchable type="desktop-id">goldendict.desktop</launchable>
+  <content_rating type="oars-1.0" />
 </component>


### PR DESCRIPTION
This commit adds missing components in goldendict.appdata.xml and makes it pass the relaxed appstream validation: `appstream-util validate-relax goldendict.appdata.xml`.