### PR TITLE
correct some comment

### DIFF
--- a/hotkeywrapper.cc
+++ b/hotkeywrapper.cc
@@ -278,7 +278,7 @@ bool HotkeyWrapper::checkState(quint32 vk, quint32 mod)
 
       // Grab the second key, unless it's grabbed already
       // Note that we only grab the clipboard key only if
-      // the sequence didn't begin with it
+      // the sequence begins with it
 
       if ( ( isCopyToClipboardKey( hs.key, hs.modifier ) ||
              !isCopyToClipboardKey( hs.key2, hs.modifier ) ) &&


### PR DESCRIPTION
the following table can be obtained from the code logic (and I also tested it on my computer):

| globalhotkey keystroke1 | globalhotkey keystroke2 | behavior                                           |
|-------------------------|-------------------------|----------------------------------------------------|
| non ctrl+c              | non ctrl+c              | both keystroke1, keystroke2 were grabbed in order  |
| non ctrl+c              | ctrl+c                  | keystroke1 was grabbed, keystroke2 was not grabbed |
| ctrl+c                  | non ctrl+c              | keystroke1 was not grabbed, keystroke2 was grabbed |
| ctrl+c                  | ctrl+c                  | keystroke1 was not grabbed, keystroke2 was grabbed |

obviously, the key2 (whether is clipboard key or not) will be grabbed only if the sequence ***does*** begin with the clipboard key.