### PR TITLE
Use a better workaround for Wayland crashes

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -212,6 +212,17 @@ public:
 
 int main( int argc, char ** argv )
 {
+#ifdef Q_OS_UNIX
+    // GoldenDict use lots of X11 functions and it currently cannot work
+    // natively on Wayland. This workaround will force GoldenDict to use
+    // XWayland.
+    char * xdg_envc = getenv("XDG_SESSION_TYPE");
+    QString xdg_session = xdg_envc ? QString::fromLatin1(xdg_envc) : QString();
+    if (!QString::compare(xdg_session, QString("wayland"), Qt::CaseInsensitive))
+    {
+        setenv("QT_QPA_PLATFORM", "xcb", 1);
+    }
+#endif
   #ifdef Q_OS_MAC
     setenv("LANG", "en_US.UTF-8", 1);
 

--- a/redist/goldendict.desktop
+++ b/redist/goldendict.desktop
@@ -7,8 +7,3 @@ GenericName=Multiformat Dictionary
 Comment=GoldenDict
 Icon=goldendict
 Exec=goldendict
-Actions=X11;
-
-[Desktop Action X11]
-Name=GoldenDict (X11)
-Exec=env QT_QPA_PLATFORM=xcb goldendict


### PR DESCRIPTION
GoldenDict use lots of X11 functions and it currently cannot work natively on Wayland. This workaround will force GoldenDict to use  XWayland.

Closes #1200. Closes #935.