### PR TITLE
Use standard directory to store files, fix most deprecated warnings

### DIFF
--- a/aard.cc
+++ b/aard.cc
@@ -959,7 +959,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries(
           if( volumes > 1 )
           {
             QString ss;
-            ss.sprintf( " (%i/%i)", qFromBigEndian( dictHeader.volume ), volumes );
+            ss.asprintf( " (%i/%i)", qFromBigEndian( dictHeader.volume ), volumes );
             dictName += ss.toLocal8Bit().data();
           }
 

--- a/article_netmgr.cc
+++ b/article_netmgr.cc
@@ -403,8 +403,8 @@ sptr< Dictionary::DataRequest > ArticleNetworkAccessManager::getResource(
 
     // See if we have some dictionaries muted
 
-    QSet< QString > mutedDicts =
-        QSet< QString >::fromList( Qt4x5::Url::queryItemValue( url, "muted" ).split( ',' ) );
+    auto lst = Qt4x5::Url::queryItemValue( url, "muted" ).split( ',' );
+    QSet<QString> mutedDicts = QSet<QString>( lst.begin(), lst.end() );
 
     // Unpack contexts
 

--- a/btreeidx.cc
+++ b/btreeidx.cc
@@ -1418,7 +1418,7 @@ void BtreeIndex::getHeadwordsFromOffsets( QList<uint32_t> & offsets,
   uint32_t nextLeaf = 0;
   uint32_t leafEntries;
 
-  qSort( offsets );
+  std::sort( offsets.begin(), offsets.end() );
 
   Mutex::Lock _( *idxFileMutex );
 
@@ -1481,10 +1481,10 @@ void BtreeIndex::getHeadwordsFromOffsets( QList<uint32_t> & offsets,
 
     for( unsigned i = 0; i < result.size(); i++ )
     {
-      QList< uint32_t >::Iterator it = qBinaryFind( begOffsets, endOffsets,
+      QList< uint32_t >::Iterator it = std::lower_bound( begOffsets, endOffsets,
                                                     result.at( i ).articleOffset );
 
-      if( it != offsets.end() )
+      if( it != offsets.end() && *it == result.at( i ).articleOffset )
       {
         if( isCancelled && Qt4x5::AtomicInt::loadAcquire( *isCancelled ) )
           return;

--- a/btreeidx.hh
+++ b/btreeidx.hh
@@ -7,6 +7,7 @@
 #include "dictionary.hh"
 #include "file.hh"
 
+#include <algorithm>
 #include <string>
 #include <vector>
 #include <map>
@@ -195,7 +196,7 @@ public:
   // Default - simple sorting in increase order
   virtual void sortArticlesOffsetsForFTS( QVector< uint32_t > & offsets,
                                           QAtomicInt & isCancelled )
-  { Q_UNUSED( isCancelled ); qSort( offsets ); }
+  { Q_UNUSED( isCancelled ); std::sort( offsets.begin(), offsets.end() ); }
 
   /// Called before each matching operation to ensure that any child init
   /// has completed. Mainly used for deferred init. The default implementation

--- a/config.cc
+++ b/config.cc
@@ -1,6 +1,7 @@
 /* This file is (c) 2008-2012 Konstantin Isakov <ikm@goldendict.org>
  * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
 
+#include <iostream>
 #include "config.hh"
 #include <QDir>
 #include <QFile>
@@ -39,12 +40,17 @@ namespace
       char const * pathInHome = "GoldenDict";
       result = QDir::fromNativeSeparators( QString::fromWCharArray( _wgetenv( L"APPDATA" ) ) );
     #else
-      char const * pathInHome = QStandardPaths::locate(QStandardPaths::ConfigLocation, "goldendict", QStandardPaths::LocateDirectory).toStdString().c_str();
+      QString configPath = QStandardPaths::writableLocation(QStandardPaths::ConfigLocation);
+      if (configPath.isEmpty()) {
+          configPath = ".config";
+      }
+      configPath += "/goldendict";
+      std::string pathInHome = configPath.toStdString();
     #endif
 
-    result.mkpath( pathInHome );
+    result.mkpath( pathInHome.c_str() );
 
-    if ( !result.cd( pathInHome ) )
+    if ( !result.cd( pathInHome.c_str() ) )
       throw exCantUseHomeDir();
 
     return result;

--- a/config.cc
+++ b/config.cc
@@ -1,7 +1,6 @@
 /* This file is (c) 2008-2012 Konstantin Isakov <ikm@goldendict.org>
  * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
 
-#include <iostream>
 #include "config.hh"
 #include <QDir>
 #include <QFile>

--- a/config.cc
+++ b/config.cc
@@ -6,6 +6,7 @@
 #include <QFile>
 #include <QtXml>
 #include "gddebug.hh"
+#include <QStandardPaths>
 
 #if defined( _MSC_VER ) && _MSC_VER < 1800 // VS2012 and older
 #include <stdint_msvc.h>
@@ -38,7 +39,7 @@ namespace
       char const * pathInHome = "GoldenDict";
       result = QDir::fromNativeSeparators( QString::fromWCharArray( _wgetenv( L"APPDATA" ) ) );
     #else
-      char const * pathInHome = ".goldendict";
+      char const * pathInHome = QStandardPaths::locate(QStandardPaths::ConfigLocation, "goldendict", QStandardPaths::LocateDirectory).toStdString().c_str();
     #endif
 
     result.mkpath( pathInHome );

--- a/extlineedit.cc
+++ b/extlineedit.cc
@@ -113,13 +113,11 @@ void ExtLineEdit::updateButtonPositions()
             iconPos = (iconPos == Left ? Right : Left);
 
         if (iconPos == ExtLineEdit::Right) {
-            int right;
-            getTextMargins(0, 0, &right, 0);
+            int right = textMargins().right();
             const int iconoffset = right + 4;
             iconButtons[i]->setGeometry(contentRect.adjusted(width() - iconoffset, 0, 0, 0));
         } else {
-            int left;
-            getTextMargins(&left, 0, 0, 0);
+            int left = textMargins().left();
             const int iconoffset = left + 4;
             iconButtons[i]->setGeometry(contentRect.adjusted(0, 0, -width() + iconoffset, 0));
         }

--- a/favoritespanewidget.cc
+++ b/favoritespanewidget.cc
@@ -906,7 +906,7 @@ void FavoritesModel::removeItemsForIndexes( const QModelIndexList & idxList )
   for( int i = lowestLevel; i >= 0; i-- )
   {
     QModelIndexList idxSublist = itemsToDelete[ i ];
-    qSort( idxSublist.begin(), idxSublist.end(), qGreater< QModelIndex >() );
+    std::sort( idxSublist.begin(), idxSublist.end(), qGreater< QModelIndex >() );
 
     it = idxSublist.begin();
     for( ; it != idxSublist.end(); ++it )

--- a/fulltextsearch.cc
+++ b/fulltextsearch.cc
@@ -649,8 +649,8 @@ Q_UNUSED( parent );
 
   for( int x = 0; x < hws.length(); x++ )
   {
-    QList< FtsHeadword >::iterator it = qBinaryFind( headwords.begin(), headwords.end(), hws.at( x ) );
-    if( it != headwords.end() )
+    QList< FtsHeadword >::iterator it = std::lower_bound( headwords.begin(), headwords.end(), hws.at( x ) );
+    if( it != headwords.end() && *it == hws.at( x ))
     {
       it->dictIDs.push_back( hws.at( x ).dictIDs.front() );
       for( QStringList::const_iterator itr = it->foundHiliteRegExps.constBegin();
@@ -665,7 +665,7 @@ Q_UNUSED( parent );
   }
 
   headwords.append( temp );
-  qSort( headwords );
+  std::sort( headwords.begin(), headwords.end() );
 
   endResetModel();
   emit contentChanged();

--- a/gddebug.cc
+++ b/gddebug.cc
@@ -23,7 +23,7 @@ QTextCodec *localeCodec = 0;
     QTextCodec::setCodecForLocale( utf8Codec );
   }
 
-  qWarning( "%s", QString().vsprintf( msg, ap ).toUtf8().data() );
+  qWarning( "%s", QString().vasprintf( msg, ap ).toUtf8().data() );
 
   if( logFilePtr && logFilePtr->isOpen() )
   {
@@ -48,7 +48,7 @@ QTextCodec *localeCodec = 0;
     QTextCodec::setCodecForLocale( utf8Codec );
   }
 
-  qDebug( "%s", QString().vsprintf( msg, ap ).toUtf8().data() );
+  qDebug( "%s", QString().vasprintf( msg, ap ).toUtf8().data() );
 
   if( logFilePtr && logFilePtr->isOpen() )
   {

--- a/historypanewidget.cc
+++ b/historypanewidget.cc
@@ -137,7 +137,7 @@ void HistoryPaneWidget::deleteSelectedItems()
 
   // Need to sort indexes in the decreasing order so that
   // the first deletions won't affect the indexes for subsequent deletions.
-  qSort( idxsToDelete.begin(), idxsToDelete.end(), qGreater<int>() );
+  std::sort( idxsToDelete.begin(), idxsToDelete.end(), qGreater<int>() );
 
   QListIterator<int> idxs( idxsToDelete );
   while ( idxs.hasNext() )

--- a/scanflag.cc
+++ b/scanflag.cc
@@ -1,5 +1,6 @@
 #include <QCursor>
 #include <QDesktopWidget>
+#include <QScreen>
 
 #include "scanflag.hh"
 #include "ui_scanflag.h"
@@ -55,7 +56,7 @@ void ScanFlag::showScanFlag()
 
   QPoint currentPos = QCursor::pos();
 
-  QRect desktop = QApplication::desktop()->screenGeometry();
+  QRect desktop = QGuiApplication::screens().first()->geometry();
 
   QSize windowSize = geometry().size();
 

--- a/scanpopup.cc
+++ b/scanpopup.cc
@@ -8,6 +8,7 @@
 #include <QPixmap>
 #include <QBitmap>
 #include <QMenu>
+#include <QScreen>
 #include <QMouseEvent>
 #include <QDesktopWidget>
 #include "gddebug.hh"
@@ -634,7 +635,7 @@ void ScanPopup::engagePopup( bool forcePopup, bool giveFocus )
 
       QPoint currentPos = QCursor::pos();
 
-      QRect desktop = QApplication::desktop()->screenGeometry();
+      QRect desktop = QGuiApplication::screens().first()->geometry();
 
       QSize windowSize = geometry().size();
 


### PR DESCRIPTION
I fixed most deprecated warnings by using the replacement the warning message suggested. There is still a deprecated warning about font I can't fix because I don't confident enough knowledge that what I do is right. There are also some warnings about comparing signed and unsigned number, but it looks more like bit-by-bit comparisons so I leave them intact.

I also moved `~/.goldendict` to `$XDG_CONFIG_HOME/goldendict` (I use `~/.config/goldendict` as default). Note that `XDG_CONFIG_HOME` environment variable must be set to make Qt return correct path, when I use `user-dirs.dirs` file the method return empty string.