### PR TITLE
Fixed build with GCC 11

### DIFF
--- a/ripemd.cc
+++ b/ripemd.cc
@@ -18,6 +18,7 @@
 
 #include "ripemd.hh"
 
+#include <limits>
 #include <string.h>
 #include <QtEndian>
 


### PR DESCRIPTION
Fixed build with GCC 11 by adding `limits` header.