### PR TITLE
double-click on images

### DIFF
--- a/articleview.cc
+++ b/articleview.cc
@@ -2230,7 +2230,7 @@ void ArticleView::doubleClicked( QPoint pos )
   QWebHitTestResult r = ui.definition->page()->mainFrame()->hitTestContent( pos );
   QWebElement el = r.element();
   QUrl imageUrl;
-  if( !popupView && el.tagName().compare( "img", Qt::CaseInsensitive ) == 0 )
+  if( el.tagName().compare( "img", Qt::CaseInsensitive ) == 0 )
   {
     // Double click on image; download it and transfer to external program
 


### PR DESCRIPTION
Issue  #1279

1. Activate double-click in popup window
1. ~~Cache images downloaded from the internet, so no need to download them again on double-click~~