### PR TITLE
articleSizeLimit option: minor code cleanup

### DIFF
--- a/config.cc
+++ b/config.cc
@@ -907,7 +907,7 @@ Class load() THROW_SPEC( exError )
       c.preferences.collapseBigArticles = ( preferences.namedItem( "collapseBigArticles" ).toElement().text() == "1" );
 
     if ( !preferences.namedItem( "articleSizeLimit" ).isNull() )
-      c.preferences.articleSizeLimit = preferences.namedItem( "articleSizeLimit" ).toElement().text().toUInt() ;
+      c.preferences.articleSizeLimit = preferences.namedItem( "articleSizeLimit" ).toElement().text().toInt();
 
     if ( !preferences.namedItem( "maxDictionaryRefsInContextMenu" ).isNull() )
       c.preferences.maxDictionaryRefsInContextMenu = preferences.namedItem( "maxDictionaryRefsInContextMenu" ).toElement().text().toUShort();

--- a/preferences.cc
+++ b/preferences.cc
@@ -417,7 +417,7 @@ Config::Preferences Preferences::getPreferences()
   p.confirmFavoritesDeletion = ui.confirmFavoritesDeletion->isChecked();
 
   p.collapseBigArticles = ui.collapseBigArticles->isChecked();
-  p.articleSizeLimit = ui.articleSizeLimit->text().toInt();
+  p.articleSizeLimit = ui.articleSizeLimit->value();
   p.ignoreDiacritics = ui.ignoreDiacritics->isChecked();
 
   p.synonymSearchEnabled = ui.synonymSearchEnabled->isChecked();


### PR DESCRIPTION
When an integral value is converted to a signed integer type, if the
result is not representable, the resulting value is implementation
defined (until C++20). Convert the string value from configuration file
to the target type (int) to avoid the redundant type conversion.

Use the more direct and efficient [`QSpinBox::value()`](https://doc.qt.io/qt-5/qspinbox.html#value-prop) (available in [Qt 4](https://doc.qt.io/archives/qt-4.8/qspinbox.html#value-prop) too) instead of [`QAbstractSpinBox::text().toInt()`](https://doc.qt.io/qt-5/qabstractspinbox.html#text-prop).