### PR TITLE
add MIME extension to tmp-filename

### DIFF
--- a/articleview.cc
+++ b/articleview.cc
@@ -2033,8 +2033,15 @@ void ArticleView::resourceDownloadFinished()
           QString fileName;
 
           {
-            QTemporaryFile tmp(
-              QDir::temp().filePath( "XXXXXX-" + resourceDownloadUrl.path().section( '/', -1 ) ), this );
+            fileName = QDir::temp().filePath( "XXXXXX-" + resourceDownloadUrl.path().section( '/', -1 ) );
+
+            QString mimeType = (*i)->getMimeType();
+            if ( mimeType.startsWith("image/") )
+            {
+                fileName = fileName + "." + mimeType.remove(0, 6);
+            }
+
+            QTemporaryFile tmp( fileName, this );
 
             if ( !tmp.open() || (size_t) tmp.write( &data.front(), data.size() ) != data.size() )
             {

--- a/dictionary.cc
+++ b/dictionary.cc
@@ -138,6 +138,14 @@ vector< char > & DataRequest::getFullData() THROW_SPEC( exRequestUnfinished )
   return data;
 }
 
+QString & DataRequest::getMimeType() THROW_SPEC( exRequestUnfinished )
+{
+  if ( !isFinished() )
+    throw exRequestUnfinished();
+
+  return mimeType;
+}
+
 Class::Class( string const & id_, vector< string > const & dictionaryFiles_ ):
   id( id_ ), dictionaryFiles( dictionaryFiles_ ), dictionaryIconLoaded( false )
   , can_FTS( false), FTS_index_completed( false )

--- a/dictionary.hh
+++ b/dictionary.hh
@@ -196,6 +196,9 @@ public:
 
   DataRequest(): hasAnyData( false ) {}
 
+  /// Returns file format declared by webserver
+  QString & getMimeType() THROW_SPEC( exRequestUnfinished );
+
 protected:
 
   // Subclasses should be filling up the 'data' array, locking the mutex when
@@ -204,6 +207,7 @@ protected:
 
   bool hasAnyData; // With this being false, dataSize() always returns -1
   vector< char > data;
+  QString mimeType; // format of the downloaded file
 };
 
 /// A helper class for synchronous word search implementations.

--- a/webmultimediadownload.cc
+++ b/webmultimediadownload.cc
@@ -68,6 +68,9 @@ void WebMultimediaDownload::replyFinished( QNetworkReply * r )
     r->read( data.data(), data.size() );
 
     hasAnyData = true;
+
+    QVariant contentMimeType = r->header(QNetworkRequest::ContentTypeHeader);
+    mimeType = contentMimeType.toString();
   }
   else
     setErrorString( r->errorString() );


### PR DESCRIPTION
Add correct MIME extension to temporary filenames, #1279

When user double-click on the image and its `href` parameter points to online resource (`http://` or `https://`), GoldenDict downloads this image from the Internet, save it to a temporary file and execute external application associated with this type of files (i.e. image viewer).

This approach works correctly on Linux (and probably macOS). Windows detects file types using filename extension (such as `.png` for images), so name of the temporary file need to have the correct extension. Current implementation tries to use URL in naming files but it fails in some particular cases.

For example, this URL links JPEG file (not SVG):
```
https://reader.digitale-sammlungen.de/object/bsb10585036_00015.svg
```

Use [test.zip](https://github.com/goldendict/goldendict/files/5524723/test.zip) for more examples.

The proposed code names files according to the MIME information provided by remote server.