### PR TITLE
Add options to limit input phrase length

### DIFF
--- a/articleview.cc
+++ b/articleview.cc
@@ -2085,11 +2085,7 @@ void ArticleView::audioPlayerError( QString const & message )
 
 void ArticleView::pasteTriggered()
 {
-  QString text =
-      gd::toQString(
-          Folding::trimWhitespaceOrPunct(
-              gd::toWString(
-                  QApplication::clipboard()->text() ) ) );
+  QString text = cfg.preferences.sanitizeInputPhrase( QApplication::clipboard()->text() );
 
   if ( text.size() )
   {

--- a/config.hh
+++ b/config.hh
@@ -319,6 +319,10 @@ struct Preferences
   bool collapseBigArticles;
   int articleSizeLimit;
 
+  bool limitInputPhraseLength;
+  int inputPhraseLengthLimit;
+  QString sanitizeInputPhrase( QString const & inputPhrase ) const;
+
   unsigned short maxDictionaryRefsInContextMenu;
 #ifndef Q_WS_X11
   bool trackClipboardChanges;

--- a/preferences.cc
+++ b/preferences.cc
@@ -205,6 +205,8 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
 
   ui.collapseBigArticles->setChecked( p.collapseBigArticles );
   ui.articleSizeLimit->setValue( p.articleSizeLimit );
+  ui.limitInputPhraseLength->setChecked( p.limitInputPhraseLength );
+  ui.inputPhraseLengthLimit->setValue( p.inputPhraseLengthLimit );
   ui.ignoreDiacritics->setChecked( p.ignoreDiacritics );
 
   ui.synonymSearchEnabled->setChecked( p.synonymSearchEnabled );
@@ -418,6 +420,8 @@ Config::Preferences Preferences::getPreferences()
 
   p.collapseBigArticles = ui.collapseBigArticles->isChecked();
   p.articleSizeLimit = ui.articleSizeLimit->value();
+  p.limitInputPhraseLength = ui.limitInputPhraseLength->isChecked();
+  p.inputPhraseLengthLimit = ui.inputPhraseLengthLimit->value();
   p.ignoreDiacritics = ui.ignoreDiacritics->isChecked();
 
   p.synonymSearchEnabled = ui.synonymSearchEnabled->isChecked();

--- a/preferences.ui
+++ b/preferences.ui
@@ -1681,57 +1681,90 @@ It is not needed to select this option if you don't use such programs.</string>
           <string>Articles</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_3">
-          <item row="1" column="0">
-           <layout class="QHBoxLayout" name="horizontalLayout_11">
-            <item>
-             <widget class="QCheckBox" name="collapseBigArticles">
-              <property name="toolTip">
-               <string>Select this option to automatic collapse big articles</string>
-              </property>
-              <property name="text">
-               <string>Collapse articles more than</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QSpinBox" name="articleSizeLimit">
-              <property name="toolTip">
-               <string>Articles longer than this size will be collapsed</string>
-              </property>
-              <property name="maximum">
-               <number>100000</number>
-              </property>
-              <property name="singleStep">
-               <number>50</number>
-              </property>
-              <property name="value">
-               <number>2000</number>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLabel" name="label_13">
-              <property name="text">
-               <string>symbols</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_11">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
+          <item row="0" column="0">
+           <widget class="QCheckBox" name="collapseBigArticles">
+            <property name="toolTip">
+             <string>Select this option to automatic collapse big articles</string>
+            </property>
+            <property name="text">
+             <string>Collapse articles more than</string>
+            </property>
+           </widget>
           </item>
           <item row="0" column="1">
+           <widget class="QSpinBox" name="articleSizeLimit">
+            <property name="toolTip">
+             <string>Articles longer than this size will be collapsed</string>
+            </property>
+            <property name="maximum">
+             <number>100000</number>
+            </property>
+            <property name="singleStep">
+             <number>50</number>
+            </property>
+            <property name="value">
+             <number>2000</number>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="QLabel" name="label_13">
+            <property name="text">
+             <string>symbols</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="3">
+           <spacer name="horizontalSpacer_11">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="limitInputPhraseLength">
+            <property name="toolTip">
+             <string>Turn this option on to ignore unreasonably long input text
+from mouse-over, selection, clipboard or command line</string>
+            </property>
+            <property name="text">
+             <string>Ignore input phrases longer than</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QSpinBox" name="inputPhraseLengthLimit">
+            <property name="toolTip">
+             <string>Input phrases longer than this size will be ignored</string>
+            </property>
+            <property name="maximum">
+             <number>10000</number>
+            </property>
+            <property name="singleStep">
+             <number>5</number>
+            </property>
+            <property name="value">
+             <number>200</number>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QLabel" name="label_19">
+            <property name="text">
+             <string>symbols</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="4">
            <widget class="QCheckBox" name="ignoreDiacritics">
             <property name="toolTip">
              <string>Turn this option on to ignore diacritics while searching articles</string>
@@ -1741,7 +1774,7 @@ It is not needed to select this option if you don't use such programs.</string>
             </property>
            </widget>
           </item>
-          <item row="0" column="0">
+          <item row="0" column="4">
            <widget class="QCheckBox" name="alwaysExpandOptionalParts">
             <property name="toolTip">
              <string>Turn this option on to always expand optional parts of articles</string>
@@ -1751,7 +1784,7 @@ It is not needed to select this option if you don't use such programs.</string>
             </property>
            </widget>
           </item>
-          <item row="0" column="2">
+          <item row="1" column="3">
            <spacer name="horizontalSpacer_14">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>

--- a/scanpopup.cc
+++ b/scanpopup.cc
@@ -2,8 +2,6 @@
  * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
 
 #include "scanpopup.hh"
-#include "folding.hh"
-#include "wstring_qt.hh"
 #include <QCursor>
 #include <QPixmap>
 #include <QBitmap>
@@ -494,7 +492,7 @@ void ScanPopup::translateWordFromClipboard(QClipboard::Mode m)
 
 void ScanPopup::translateWord( QString const & word )
 {
-  QString str = pendingInputWord = gd::toQString( Folding::trimWhitespaceOrPunct( gd::toWString( word ) ) ).simplified();
+  QString str = pendingInputWord = cfg.preferences.sanitizeInputPhrase( word );
 
   if ( !str.size() )
     return; // Nothing there
@@ -558,7 +556,7 @@ void ScanPopup::mouseHovered( QString const & str, bool forcePopup )
 
 void ScanPopup::handleInputWord( QString const & str, bool forcePopup )
 {
-  QString sanitizedStr = gd::toQString( Folding::trimWhitespaceOrPunct( gd::toWString( str ) ) ).simplified();
+  QString sanitizedStr = cfg.preferences.sanitizeInputPhrase( str );
 
   if ( isVisible() && sanitizedStr == inputWord )
   {


### PR DESCRIPTION
When a long text is accidentally selected or copied while the scan popup
is on, Goldendict spends a lot of CPU time to gradually create a
"No translation..." article. When translation of huge (e.g. 15 MB) text
from the clipboard is (accidentally) requested, Goldendict freezes for a
while. Turning the added input phrase limit option on eliminates this
waste of the CPU time.

I have implemented these options primarily for selection and clipboard,
but they also affect mouse-over translation on Windows and command line
translation requests. This is mostly because I did not bother to limit
the options' scope. I guess hovering over an extremely long text without
spaces (e.g. Base64-encoded) could cause the same performance issue on
Windows. The command-line translation could be requested from a script
that integrates Goldendict with some other application, from which long
text could be sent for translation by accident.

I hope that the default value of 200 characters will be sufficient for
just about any real-world user input in any language. The option is on
by default, because the default length limit is generous and any longer
text is unlikely to be sent for translation intentionally. My personal
preference for the input phrase length limit is 100 symbols.

ArticleView::pasteTriggered() didn't call QString::simplified() on the
text retrieved from the clipboard. I assumed this was an oversight, so
now it *is* called - indirectly, via Preferences::sanitizeInputPhrase().