### PR TITLE
Set up network disk cache for articleNetMgr

### DIFF
--- a/config.hh
+++ b/config.hh
@@ -302,6 +302,8 @@ struct Preferences
   bool disallowContentFromOtherSites;
   bool enableWebPlugins;
   bool hideGoldenDictHeader;
+  int maxNetworkCacheSize;
+  bool clearNetworkCacheOnExit;
 
   qreal zoomFactor;
   qreal helpZoomFactor;
@@ -791,6 +793,12 @@ QString getPortableVersionMorphoDir() throw();
 
 /// Returns the add-on styles directory.
 QString getStylesDir() throw();
+
+/// Returns the directory where user-specific non-essential (cached) data should be written.
+QString getCacheDir() throw();
+
+/// Returns the article network disk cache directory.
+QString getNetworkCacheDir() throw();
 
 }
 

--- a/mainwindow.hh
+++ b/mainwindow.hh
@@ -201,6 +201,7 @@ private:
 
   void applyProxySettings();
   void applyWebSettings();
+  void setupNetworkCache( int maxSize );
   void makeDictionaries();
   void updateStatusLine();
   void updateGroupList();

--- a/preferences.cc
+++ b/preferences.cc
@@ -153,6 +153,12 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
       break;
     }
 
+#ifdef Q_OS_WIN32
+  // 1 MB stands for 2^20 bytes on Windows. "MiB" is never used by this OS.
+  ui.maxNetworkCacheSize->setSuffix( tr( " MB" ) );
+#endif
+  ui.maxNetworkCacheSize->setToolTip( ui.maxNetworkCacheSize->toolTip().arg( Config::getNetworkCacheDir() ) );
+
   ui.newTabsOpenAfterCurrentOne->setChecked( p.newTabsOpenAfterCurrentOne );
   ui.newTabsOpenInBackground->setChecked( p.newTabsOpenInBackground );
   ui.hideSingleTab->setChecked( p.hideSingleTab );
@@ -319,6 +325,8 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
   ui.disallowContentFromOtherSites->setChecked( p.disallowContentFromOtherSites );
   ui.enableWebPlugins->setChecked( p.enableWebPlugins );
   ui.hideGoldenDictHeader->setChecked( p.hideGoldenDictHeader );
+  ui.maxNetworkCacheSize->setValue( p.maxNetworkCacheSize );
+  ui.clearNetworkCacheOnExit->setChecked( p.clearNetworkCacheOnExit );
 
   // Add-on styles
   ui.addonStylesLabel->setVisible( ui.addonStyles->count() > 1 );
@@ -449,6 +457,8 @@ Config::Preferences Preferences::getPreferences()
   p.disallowContentFromOtherSites = ui.disallowContentFromOtherSites->isChecked();
   p.enableWebPlugins = ui.enableWebPlugins->isChecked();
   p.hideGoldenDictHeader = ui.hideGoldenDictHeader->isChecked();
+  p.maxNetworkCacheSize = ui.maxNetworkCacheSize->value();
+  p.clearNetworkCacheOnExit = ui.clearNetworkCacheOnExit->isChecked();
 
   p.addonStyle = ui.addonStyles->getCurrentStyle();
 
@@ -637,6 +647,11 @@ void Preferences::customProxyToggled( bool )
 {
   ui.customSettingsGroup->setEnabled( ui.customProxy->isChecked()
                                       && ui.useProxyServer->isChecked() );
+}
+
+void Preferences::on_maxNetworkCacheSize_valueChanged( int value )
+{
+    ui.clearNetworkCacheOnExit->setEnabled( value != 0 );
 }
 
 void Preferences::helpRequested()

--- a/preferences.hh
+++ b/preferences.hh
@@ -52,6 +52,7 @@ private slots:
   void on_useExternalPlayer_toggled( bool enabled );
 
   void customProxyToggled( bool );
+  void on_maxNetworkCacheSize_valueChanged( int value );
 
   void helpRequested();
   void closeHelp();

--- a/preferences.ui
+++ b/preferences.ui
@@ -1153,6 +1153,59 @@ Enable this option to workaround the problem.</string>
         </widget>
        </item>
        <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_11">
+         <item>
+          <widget class="QLabel" name="label_20">
+           <property name="text">
+            <string>Maximum network cache size:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="maxNetworkCacheSize">
+           <property name="toolTip">
+            <string>Maximum disk space occupied by GoldenDict's network cache in
+%1
+If set to 0 the network disk cache will be disabled.</string>
+           </property>
+           <property name="suffix">
+            <string> MiB</string>
+           </property>
+           <property name="maximum">
+            <number>2000</number>
+           </property>
+           <property name="value">
+            <number>50</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="clearNetworkCacheOnExit">
+           <property name="toolTip">
+            <string>When this option is enabled, GoldenDict
+clears its network cache from disk during exit.</string>
+           </property>
+           <property name="text">
+            <string>Clear network cache on exit</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_15">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
         <spacer name="verticalSpacer_10">
          <property name="orientation">
           <enum>Qt::Vertical</enum>


### PR DESCRIPTION
When a Wikipedia article is already cached, this change reduces the
amount of sent and received network data almost tenfold.

Setting up a network disk cache in the same way for `dictNetMgr` does not
noticeably impact the amount of network traffic. Either this network
access manager sends and receives very little data or the data is never
the same. So `dictNetMgr` does not need a disk cache.

Clear network cache on exit by default because most users probably
don't load the same online articles after restarting Goldendict. Plus
storing the network cache on disk indefinitely by default would be a new
and unexpected to the users privacy risk.

Nikita Moor came up with the idea and wrote an initial network disk
cache implementation in #1310.