### PR TITLE
Add support for *.oga audio files

### DIFF
--- a/article-style.css
+++ b/article-style.css
@@ -1624,6 +1624,7 @@ in the bottom-right corner of the content area */
 	padding-right: 18px;
 }
 .mwiki #bodyContent a.external[href $=".ogg"], .mwiki #bodyContent a.external[href $=".OGG"],
+.mwiki #bodyContent a.external[href $=".oga"], .mwiki #bodyContent a.external[href $=".OGA"],
 .mwiki #bodyContent a.external[href $=".mid"], .mwiki #bodyContent a.external[href $=".MID"],
 .mwiki #bodyContent a.external[href $=".midi"], .mwiki #bodyContent a.external[href $=".MIDI"],
 .mwiki #bodyContent a.external[href $=".mp3"], .mwiki #bodyContent a.external[href $=".MP3"],

--- a/articleview.cc
+++ b/articleview.cc
@@ -1953,7 +1953,7 @@ void ArticleView::contextMenuRequested( QPoint const & pos )
         fileName = savePath + "/" + name;
         fileName = QFileDialog::getSaveFileName( parentWidget(), tr( "Save sound" ),
                                                  fileName,
-                                                 tr( "Sound files (*.wav *.ogg *.mp3 *.mp4 *.aac *.flac *.mid *.wv *.ape);;All files (*.*)" ) );
+                                                 tr( "Sound files (*.wav *.ogg *.oga *.mp3 *.mp4 *.aac *.flac *.mid *.wv *.ape);;All files (*.*)" ) );
       }
       else
       {

--- a/filetype.cc
+++ b/filetype.cc
@@ -55,6 +55,7 @@ bool isNameOfSound( string const & name )
     endsWith( s, ".au" ) ||
     endsWith( s, ".voc" ) ||
     endsWith( s, ".ogg" ) ||
+    endsWith( s, ".oga" ) ||
     endsWith( s, ".mp3" ) ||
     endsWith( s, ".m4a") ||
     endsWith( s, ".aac" ) ||

--- a/mediawiki.cc
+++ b/mediawiki.cc
@@ -480,9 +480,9 @@ void MediaWikiArticleRequest::requestFinished( QNetworkReply * r )
 #endif
             // audio url
 #if QT_VERSION >= QT_VERSION_CHECK( 5, 0, 0 )
-            articleString.replace( QRegularExpression( "<a\\s+href=\"(//upload\\.wikimedia\\.org/wikipedia/[^\"'&]*\\.ogg(?:\\.mp3|))\"" ),
+            articleString.replace( QRegularExpression( "<a\\s+href=\"(//upload\\.wikimedia\\.org/wikipedia/[^\"'&]*\\.og[ga](?:\\.mp3|))\"" ),
 #else
-            articleString.replace( QRegExp( "<a\\s+href=\"(//upload\\.wikimedia\\.org/wikipedia/[^\"'&]*\\.ogg(?:\\.mp3|))\"" ),
+            articleString.replace( QRegExp( "<a\\s+href=\"(//upload\\.wikimedia\\.org/wikipedia/[^\"'&]*\\.og[ga](?:\\.mp3|))\"" ),
 #endif
                                    QString::fromStdString( addAudioLink( string( "\"" ) + wikiUrl.scheme().toStdString() + ":\\1\"",
                                                                          this->dictPtr->getId() ) + "<a href=\"" + wikiUrl.scheme().toStdString() + ":\\1\"" ) );


### PR DESCRIPTION
For example, the first audio link in "The United States" English Wikipedia article - "The Star-Spangled Banner" - ends with ".oga".
Without this commit the audio link is not recognized by GoldenDict:
* it is not pronounced when a Preferences=>Audio=>"Auto-pronounce..." option is enabled;
* clicking on the link opens it in the default browser instead of playing inside GoldenDict.