### PR TITLE
Save&restore the geometry of Dictionaries dialog

### DIFF
--- a/config.cc
+++ b/config.cc
@@ -1100,6 +1100,11 @@ Class load() THROW_SPEC( exError )
   if ( !inspectorGeometry.isNull() )
     c.inspectorGeometry = QByteArray::fromBase64( inspectorGeometry.toElement().text().toLatin1() );
 
+  QDomNode dictionariesDialogGeometry = root.namedItem( "dictionariesDialogGeometry" );
+
+  if ( !dictionariesDialogGeometry.isNull() )
+    c.dictionariesDialogGeometry = QByteArray::fromBase64( dictionariesDialogGeometry.toElement().text().toLatin1() );
+
   QDomNode timeForNewReleaseCheck = root.namedItem( "timeForNewReleaseCheck" );
 
   if ( !timeForNewReleaseCheck.isNull() )
@@ -2092,6 +2097,10 @@ void save( Class const & c ) THROW_SPEC( exError )
 
     opt = dd.createElement( "inspectorGeometry" );
     opt.appendChild( dd.createTextNode( QString::fromLatin1( c.inspectorGeometry.toBase64() ) ) );
+    root.appendChild( opt );
+
+    opt = dd.createElement( "dictionariesDialogGeometry" );
+    opt.appendChild( dd.createTextNode( QString::fromLatin1( c.dictionariesDialogGeometry.toBase64() ) ) );
     root.appendChild( opt );
 
     opt = dd.createElement( "timeForNewReleaseCheck" );

--- a/config.hh
+++ b/config.hh
@@ -677,6 +677,7 @@ struct Class
   QByteArray popupWindowGeometry; // Geometry saved by QMainWindow
   QByteArray dictInfoGeometry; // Geometry of "Dictionary info" window
   QByteArray inspectorGeometry; // Geometry of WebKit inspector window
+  QByteArray dictionariesDialogGeometry; // Geometry of Dictionaries dialog
   QByteArray helpWindowGeometry; // Geometry of help window
   QByteArray helpSplitterState; // Geometry of help splitter
 

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -2035,7 +2035,9 @@ void MainWindow::editDictionaries( unsigned editDictionaryGroup )
   if ( editDictionaryGroup != Instances::Group::NoGroupId )
     dicts.editGroup( editDictionaryGroup );
 
+  dicts.restoreGeometry( cfg.dictionariesDialogGeometry );
   dicts.exec();
+  cfg.dictionariesDialogGeometry = newCfg.dictionariesDialogGeometry = dicts.saveGeometry();
 
   if ( dicts.areDictionariesChanged() || dicts.areGroupsChanged() )
   {


### PR DESCRIPTION
The geometries of many GoldenDict's dialogs and windows are already stored in config. Dictionaries dialog can make use of extra horizontal space when there are many groups, extra vertical space - when there are many dictionaries. A user can now resize this dialog to her liking once.