### PR TITLE
Use QStandardPaths::ConfigLocation on Qt >= 5 if old config dir is not found

### DIFF
--- a/config.cc
+++ b/config.cc
@@ -52,6 +52,14 @@ namespace
       result = QDir::fromNativeSeparators( QString::fromWCharArray( _wgetenv( L"APPDATA" ) ) );
     #else
       char const * pathInHome = ".goldendict";
+      #if QT_VERSION >= QT_VERSION_CHECK( 5, 0, 0 ) && defined( HAVE_X11 )
+        // check if an old config dir is present, otherwise use standards-compliant location
+        if ( !result.exists( pathInHome ) )
+        {
+          result.setPath( QStandardPaths::writableLocation( QStandardPaths::ConfigLocation ) );
+          pathInHome = "goldendict";
+        }
+      #endif
     #endif
 
     result.mkpath( pathInHome );

--- a/config.cc
+++ b/config.cc
@@ -2339,7 +2339,11 @@ QString getCacheDir() throw()
 {
   return isPortableVersion() ? portableHomeDirPath() + "/cache"
 #if QT_VERSION >= QT_VERSION_CHECK( 5, 0, 0 )
+  #ifdef HAVE_X11
+                             : QStandardPaths::writableLocation( QStandardPaths::GenericCacheLocation ) + "/goldendict";
+  #else
                              : QStandardPaths::writableLocation( QStandardPaths::CacheLocation );
+  #endif
 #else
                              : QDesktopServices::storageLocation( QDesktopServices::CacheLocation );
 #endif

--- a/config.cc
+++ b/config.cc
@@ -2214,6 +2214,15 @@ QString getIndexDir() THROW_SPEC( exError )
 {
   QDir result = getHomeDir();
 
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 0, 0 ) && defined( HAVE_X11 )
+  // store index in XDG_CACHE_HOME in non-portable version
+  // *and* when an old index directory in GoldenDict home doesn't exist
+  if ( !isPortableVersion() && !result.exists( "index" ) )
+  {
+    result.setPath( getCacheDir() );
+  }
+#endif
+
   result.mkpath( "index" );
 
   if ( !result.cd( "index" ) )

--- a/config.hh
+++ b/config.hh
@@ -758,6 +758,7 @@ private:
 };
 
 DEF_EX( exError, "Error with the program's configuration", std::exception )
+DEF_EX( exCantUseDataDir, "Can't use XDG_DATA_HOME directory to store GoldenDict data", exError )
 DEF_EX( exCantUseHomeDir, "Can't use home directory to store GoldenDict preferences", exError )
 DEF_EX( exCantUseIndexDir, "Can't use index directory to store GoldenDict index files", exError )
 DEF_EX( exCantReadConfigFile, "Can't read the configuration file", exError )


### PR DESCRIPTION
That fixes #151. New location is only used if no existing configuration is found. In order to migrate configuration to new location one must manually move directory.

QStandardPaths is not present prior to Qt5 (it seems Qt4 is still supported), so I added #if guard. Therefore, new configuration will not work in Qt4 builds.