### PR TITLE
Fix cmd+C+C not working under Japanese Keyboard on MacOS

### DIFF
--- a/machotkeywrapper.mm
+++ b/machotkeywrapper.mm
@@ -28,9 +28,17 @@ void createMapping()
       return;
 
     CFDataRef dataRef = ( CFDataRef )TISGetInputSourceProperty( inputSourceRef,
-                                     kTISPropertyUnicodeKeyLayoutData );
+                                     kTISPropertyUnicodeKeyLayoutData ); 
+                        // this method returns null under macos Japanese input method(and also Chinese), which causes cmd+C+C not to be registered as a hotkey
     if( !dataRef )
-      return;
+    {
+        // solve the null value under Japanese keyboard
+        inputSourceRef = TISCopyCurrentKeyboardLayoutInputSource();
+        dataRef = static_cast<CFDataRef>((TISGetInputSourceProperty(inputSourceRef, kTISPropertyUnicodeKeyLayoutData)));
+        if (!dataRef) {
+          return;
+        }
+    }
 
     const UCKeyboardLayout * keyboardLayoutPtr = ( const UCKeyboardLayout * )CFDataGetBytePtr( dataRef );
     if( !keyboardLayoutPtr )


### PR DESCRIPTION
I used goldendict under macos, and found `cmd+C+C` hotkey for "translate a word from clipboards" not working. So I tried to fix the problem and figured out that it was because of the  Japanese Keyboard which results in a NULL return value for `TISGetInputSourceProperty`. I wish my code changes can help to fix it.