### PR TITLE
Don't ignore close event

### DIFF
--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -1212,12 +1212,21 @@ void MainWindow::closeEvent( QCloseEvent * ev )
 {
   if ( cfg.preferences.enableTrayIcon && cfg.preferences.closeToTray )
   {
-    ev->ignore();
-
     if( !cfg.preferences.searchInDock )
       translateBox->setPopupEnabled( false );
 
+#ifdef HAVE_X11
+    // Don't ignore the close event, because doing so cancels session logout if
+    // the main window is visible when the user attempts to log out.
+    // The main window will be only hidden, because QApplication::quitOnLastWindowClosed
+    // property is false and Qt::WA_DeleteOnClose widget attribute is not set.
+    Q_ASSERT(!QApplication::quitOnLastWindowClosed());
+    Q_ASSERT(!testAttribute(Qt::WA_DeleteOnClose));
+#else
+    // Ignore the close event because closing the main window breaks global hotkeys on Windows.
+    ev->ignore();
     hide();
+#endif
   }
   else
   {


### PR DESCRIPTION
If GoldenDict's option "_Close to system tray_" is checked and
GoldenDict's main window is visible when the user logs out, the logout
is canceled. This occurs in latest stable versions of KDE Plasma and
Xfce GNU/Linux desktop environments. The cause of this unintended and
pointless logout cancellation is ignoring the close event.

Close events are accepted by default. `main()` calls
`app.setQuitOnLastWindowClosed( false );`. Thus, if the close event is
not touched, the main window is hidden as before this change.
GoldenDict's configuration, history and favorites are still committed
and saved in both KDE Plasma and Xfce when logging out first
closes/hides the main window, then quits GoldenDict.

Closes #1421.