### PR TITLE
add support for ffmpeg 5.0

### DIFF
--- a/ffmpegaudio.cc
+++ b/ffmpegaudio.cc
@@ -94,7 +94,11 @@ struct DecoderContext
   QByteArray audioData_;
   QDataStream audioDataStream_;
   AVFormatContext * formatContext_;
+#if LIBAVCODEC_VERSION_MAJOR < 59
   AVCodec * codec_;
+#else
+  const AVCodec * codec_;
+#endif
   AVCodecContext * codecContext_;
   AVIOContext * avioContext_;
   AVStream * audioStream_;


### PR DESCRIPTION
`libavcodec` has [changed](https://git.ffmpeg.org/gitweb/ffmpeg.git/commit/626535f6a169e2d821b969e0ea77125ba7482113) its API so that `avcodec_find_decoder` returns `const AVCodec*` now.

This fixes #1469 and #1449.