### PR TITLE
handle Ctrl+C+C can not show popup window in many Qt programs

### DIFF
--- a/scanpopup.cc
+++ b/scanpopup.cc
@@ -270,9 +270,6 @@ ScanPopup::ScanPopup( QWidget * parent,
   connect( definition, SIGNAL( titleChanged(  ArticleView *, QString const & ) ),
            this, SLOT( titleChanged(  ArticleView *, QString const & ) ) );
 
-  connect( QApplication::clipboard(), SIGNAL( dataChanged() ),
-           this, SLOT( handleTranslateWordFromClipboard() ) );
-
 #ifdef HAVE_X11
   connect( QApplication::clipboard(), SIGNAL( changed( QClipboard::Mode ) ),
            this, SLOT( clipboardChanged( QClipboard::Mode ) ) );
@@ -563,6 +560,9 @@ void ScanPopup::delayShow()
 
 void ScanPopup::clipboardChanged( QClipboard::Mode m )
 {
+  if ( isTranslateWordFromClipboard && m == TranslateWordFromClipboardMode )
+      return handleTranslateWordFromClipboard();
+
   if ( !isScanningEnabled )
     return;
 #ifdef HAVE_X11

--- a/scanpopup.cc
+++ b/scanpopup.cc
@@ -72,6 +72,8 @@ ScanPopup::ScanPopup( QWidget * parent,
   QMainWindow( parent ),
   cfg( cfg_ ),
   isScanningEnabled( false ),
+  isTranslateWordFromClipboard( false ),
+  translateWordFromClipboardMode( QClipboard::Clipboard ),
   allDictionaries( allDictionaries_ ),
   groups( groups_ ),
   history( history_ ),
@@ -479,13 +481,13 @@ Qt::WindowFlags ScanPopup::unpinnedWindowFlags() const
 
 void ScanPopup::translateWordFromClipboard()
 {
-  TranslateWordFromClipboardMode = QClipboard::Clipboard;
+  translateWordFromClipboardMode = QClipboard::Clipboard;
   setTranslateWordFromClipboard();
 }
 
 void ScanPopup::translateWordFromSelection()
 {
-  TranslateWordFromClipboardMode = QClipboard::Selection;
+  translateWordFromClipboardMode = QClipboard::Selection;
   setTranslateWordFromClipboard();
 }
 
@@ -503,15 +505,16 @@ void ScanPopup::editGroupRequested()
 
 void ScanPopup::handleTranslateWordFromClipboard()
 {
-  if(!isTranslateWordFromClipboard) return;
+  if( !isTranslateWordFromClipboard )
+    return;
 
   GD_DPRINTF( "translating from clipboard or selection\n" );
 
   QString subtype = "plain";
 
-  QString str = QApplication::clipboard()->text( subtype, TranslateWordFromClipboardMode );
+  QString str = QApplication::clipboard()->text( subtype, translateWordFromClipboardMode );
 
-  if(!str.isEmpty()) {
+  if( !str.isEmpty() ) {
     clearTranslateWordFromClipboard();
     translateWord( str );
   }
@@ -560,7 +563,7 @@ void ScanPopup::delayShow()
 
 void ScanPopup::clipboardChanged( QClipboard::Mode m )
 {
-  if ( isTranslateWordFromClipboard && m == TranslateWordFromClipboardMode )
+  if ( isTranslateWordFromClipboard && m == translateWordFromClipboardMode )
       return handleTranslateWordFromClipboard();
 
   if ( !isScanningEnabled )

--- a/scanpopup.hh
+++ b/scanpopup.hh
@@ -124,10 +124,10 @@ private:
 
   Config::Class & cfg;
   bool isScanningEnabled;
-  bool isTranslateWordFromClipboard = false;
+  bool isTranslateWordFromClipboard;
   QTimer translateWordFromClipboardDelayTimer;
   QTimer translateWordFromClipboardClearTimer;
-  QClipboard::Mode TranslateWordFromClipboardMode = QClipboard::Clipboard;
+  QClipboard::Mode translateWordFromClipboardMode;
   std::vector< sptr< Dictionary::Class > > const & allDictionaries;
   std::vector< sptr< Dictionary::Class > > dictionariesUnmuted;
   Instances::Groups const & groups;
@@ -242,6 +242,7 @@ private slots:
 
 #ifdef HAVE_X11
   void delayShow();
-#endif 
+#endif
 };
+
 #endif

--- a/scanpopup.hh
+++ b/scanpopup.hh
@@ -110,8 +110,7 @@ private:
 
   Qt::WindowFlags unpinnedWindowFlags() const;
 
-  // Translates the word from the clipboard or the clipboard selection
-  void translateWordFromClipboard(QClipboard::Mode m);
+  void setTranslateWordFromClipboard();
 
   // Hides the popup window, effectively closing it.
   void hideWindow();
@@ -125,6 +124,10 @@ private:
 
   Config::Class & cfg;
   bool isScanningEnabled;
+  bool isTranslateWordFromClipboard = false;
+  QTimer translateWordFromClipboardDelayTimer;
+  QTimer translateWordFromClipboardClearTimer;
+  QClipboard::Mode TranslateWordFromClipboardMode = QClipboard::Clipboard;
   std::vector< sptr< Dictionary::Class > > const & allDictionaries;
   std::vector< sptr< Dictionary::Class > > dictionariesUnmuted;
   Instances::Groups const & groups;
@@ -191,6 +194,9 @@ private:
 
 private slots:
 
+  // Translates the word from the clipboard or the clipboard selection
+  void handleTranslateWordFromClipboard();
+  void clearTranslateWordFromClipboard();
   void clipboardChanged( QClipboard::Mode );
   void mouseHovered( QString const & , bool forcePopup);
   void currentGroupChanged( QString const & );
@@ -236,7 +242,6 @@ private slots:
 
 #ifdef HAVE_X11
   void delayShow();
-#endif
+#endif 
 };
-
 #endif


### PR DESCRIPTION
Ctrl+C+C have some strange problems in different systems and in different Qt applications.
for example, in my current laptop, if NumLock is on, In QtCreator, Ctrl+C+C can not show popup window, and when CapsLock is on, the problem vanished.

I guess maybe that's because when the popup is triggered, the other Qt program have not finished the setText procedure.

So I connectted the dataChanged() signal to the translateWord method and add some key to make it pop out only when triggered.

tested under Ubuntu, and it worked well.

Resolves #1420, and maybe #650, #858, #1290 too.