### PR TITLE
Linux-specific: workaround of clipboard issue with Ctrl+C+C

### DIFF
--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -3105,7 +3105,19 @@ void MainWindow::hotKeyActivated( int hk )
     toggleMainWindow();
   else
   if ( scanPopup.get() )
+  {
+#ifdef HAVE_X11
+    // When the user requests translation with the Ctrl+C+C hotkey in certain apps
+    // on some GNU/Linux systems, GoldenDict appears to handle Ctrl+C+C before the
+    // active application finishes handling Ctrl+C. As a result, GoldenDict finds
+    // the clipboard empty, silently cancels the translation request, and users report
+    // that Ctrl+C+C is broken in these apps. Slightly delay handling the clipboard
+    // hotkey to give the active application more time and thus work around the issue.
+    QTimer::singleShot( 10, scanPopup.get(), SLOT( translateWordFromClipboard() ) );
+#else
     scanPopup->translateWordFromClipboard();
+#endif
+  }
 }
 
 void MainWindow::prepareNewReleaseChecks()


### PR DESCRIPTION
Resolves #1420, Resolves #650, Resolves #858. 

New PR of #1487 with the suggested solution.