### PR TITLE
fix: duplicated entries in epwing dictionary

### DIFF
--- a/epwing.cc
+++ b/epwing.cc
@@ -44,7 +44,7 @@ namespace {
 enum
 {
   Signature = 0x58575045, // EPWX on little-endian, XWPE on big-endian
-  CurrentFormatVersion = 5 + BtreeIndexing::FormatVersion + Folding::Version
+  CurrentFormatVersion = 6 + BtreeIndexing::FormatVersion + Folding::Version
 };
 
 struct IdxHeader

--- a/epwing_book.cc
+++ b/epwing_book.cc
@@ -846,7 +846,7 @@ void EpwingBook::getFirstHeadword( EpwingHeadword & head )
   fixHeadword( head.headword );
 
   EWPos epos( pos.page, pos.offset );
-  allHeadwordPositions[ head.headword ] = epos;
+  allHeadwordPositions[ head.headword ] << epos;
 }
 
 bool EpwingBook::getNextHeadword( EpwingHeadword & head )
@@ -877,13 +877,25 @@ bool EpwingBook::getNextHeadword( EpwingHeadword & head )
 
       if( allHeadwordPositions.contains( head.headword ) )
       {
-        EWPos epos = allHeadwordPositions[ head.headword ];
-        if( pos.page != epos.first || abs( pos.offset - epos.second ) > 4 )
+        // existed position
+        bool existed = false;
+        foreach( EWPos epos, allHeadwordPositions[ head.headword ] )
+        {
+          if( pos.page == epos.first && abs( pos.offset - epos.second ) <= 4 )
+          {
+            existed = true;
+            break;
+          }
+        }
+        if( !existed )
+        {
+          allHeadwordPositions[ head.headword ] << EWPos( pos.page, pos.offset );
           return true;
+        }
       }
       else
       {
-        allHeadwordPositions[ head.headword ] = EWPos( pos.page, pos.offset );
+        allHeadwordPositions[ head.headword ] << EWPos( pos.page, pos.offset );
         return true;
       }
     }
@@ -939,14 +951,26 @@ bool EpwingBook::getNextHeadword( EpwingHeadword & head )
 
     if( allHeadwordPositions.contains( head.headword ) )
     {
-      EWPos epos = allHeadwordPositions[ head.headword ];
-      if( pos.page != epos.first || abs( pos.offset - epos.second ) > 4 )
-        break;
+      // existed position
+      bool existed = false;
+      foreach( EWPos epos, allHeadwordPositions[ head.headword ] )
+      {
+        if( pos.page == epos.first && abs( pos.offset - epos.second ) <= 4 )
+        {
+          existed = true;
+          break;
+        }
+      }
+      if( !existed )
+      {
+        allHeadwordPositions[ head.headword ] << EWPos( pos.page, pos.offset );
+        return true;
+      }
     }
     else
     {
-      allHeadwordPositions[ head.headword ] = EWPos( pos.page, pos.offset );
-      break;
+      allHeadwordPositions[ head.headword ] << EWPos( pos.page, pos.offset );
+      return true;
     }
   }
 

--- a/epwing_book.hh
+++ b/epwing_book.hh
@@ -74,7 +74,7 @@ class EpwingBook
   QStringList imageCacheList, soundsCacheList, moviesCacheList, fontsCacheList;
   QMap< QString, QString > baseFontsMap, customFontsMap;
   QVector< int > refPages, refOffsets;
-  QMap< QString, EWPos > allHeadwordPositions;
+  QMap< QString, QList< EWPos > > allHeadwordPositions;
   QVector< EWPos > LinksQueue;
   int refOpenCount, refCloseCount;
   static Mutex libMutex;


### PR DESCRIPTION
skip too long headword in epwing dictionary   fix #1486 