### PR TITLE
Set current article at most once in loadFinished()

### DIFF
--- a/articleview.hh
+++ b/articleview.hh
@@ -319,7 +319,8 @@ private:
 
   /// Sets the current article by executing a javascript code.
   /// If moveToIt is true, it moves the focus to it as well.
-  void setCurrentArticle( QString const &, bool moveToIt = false );
+  /// Returns true in case of success, false otherwise.
+  bool setCurrentArticle( QString const &, bool moveToIt = false );
 
   /// Checks if the given article in form of "gdfrom-xxx" is inside a "website"
   /// frame.


### PR DESCRIPTION
When the current article is set and the user expands or collapses optional parts (e.g. via the Ctrl+* shortcut),
`ArticleView::setCurrentArticle()` is called twice from `ArticleView::loadFinished()`. Furthermore, the window scroll position is restored before the second jump. This is wasteful. Move the higher-priority `setCurrentArticle()` call up and, if it succeeds, skip the other call and the scrolling.

I have measured the time spent running the affected code fragment on my GNU/Linux system before and at this commit. When the loaded articles are not very large, the performance gain of this commit is only about 1 ms. However, when one of the displayed articles was huge (the "United States" English Wikipedia article), the time went from 120 ms to 5 ms.