### PR TITLE
Remove a redundant applyWordsZoomLevel() call

### DIFF
--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -825,7 +825,6 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   // Update zoomers
   adjustCurrentZoomFactor();
   scaleArticlesByCurrentZoomFactor();
-  applyWordsZoomLevel();
 
   // Update autostart info
   setAutostart(cfg.preferences.autoStart);


### PR DESCRIPTION
`applyWordsZoomLevel()` is called from `MainWindow::MainWindow()` after `MainWindow::updateSearchPaneAndBar()` even though the latter unconditionally calls `applyWordsZoomLevel()` on its own. Thus the removed function call is redundant as it always reapplies the same zoom level.

This redundant call should have been removed in 6c032b518530a7225d3e4f0f64ebd8794af99f7b when `updateSearchPaneAndBar()` started calling `applyWordsZoomLevel()`.