### PR TITLE
Don't update state prematurely in showTranslationFor()

### DIFF
--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -2806,11 +2806,6 @@ void MainWindow::showTranslationFor( Config::InputPhrase const & phrase,
 
   view->showDefinition( phrase, group, scrollTo );
 
-  updatePronounceAvailability();
-  updateFoundInDictsList();
-
-  updateBackForwardButtons();
-
   #if 0
   QUrl req;
 
@@ -2917,11 +2912,6 @@ void MainWindow::showTranslationFor( QString const & inWord,
   view->showDefinition( inWord, dictIDs, searchRegExp,
                         groupInstances[ groupList->currentIndex() ].id,
                         ignoreDiacritics );
-
-  updatePronounceAvailability();
-  updateFoundInDictsList();
-
-  updateBackForwardButtons();
 }
 
 #ifdef HAVE_X11


### PR DESCRIPTION
`MainWindow::showTranslationFor()` overloads disable the "Pronounce Word" action, then call `ArticleView::showDefinition()`. And then immediately update pronounce availability, Found in Dictionaries list, Back and Forward buttons. Since `ArticleView::showDefinition()` loads the requested page asynchronously, the previous page is still current. Therefore the "Pronounce Word" action is immediately re-enabled (if the still-current article has sounds), the other state updates have no effect whatsoever. Once the new page is loaded, the state is updated again in `MainWindow::pageLoaded()` - this time with the desired effect.

So the only effect of the state updates in `MainWindow::showTranslationFor()` is to revert the intentional disabling of the "Pronounce Word" action. Plus waste some CPU time. The pronunciation-disabling behavior looks better to me and is consistent with the scan popup's behavior (which immediately hides the "Pronounce Word" button).