### PR TITLE
opt: print _MSC_FULL_VER instead of incorrect VS version

### DIFF
--- a/about.cc
+++ b/about.cc
@@ -23,10 +23,8 @@ About::About( QWidget * parent ): QDialog( parent )
   ui.version->setText( version );
 
 #if defined (_MSC_VER)
-  QString compilerVersion = QString( "Visual C++ %1.%2.%3" )
-                               .arg( GD_CXX_MSVC_MAJOR )
-                               .arg( GD_CXX_MSVC_MINOR )
-                               .arg( GD_CXX_MSVC_BUILD );
+  QString compilerVersion = QString( "Visual C++ Compiler: %1" )
+                               .arg( _MSC_FULL_VER );
 #elif defined (__clang__) && defined (__clang_version__)
   QString compilerVersion = QLatin1String( "Clang " ) + QLatin1String( __clang_version__ );
 #else

--- a/about.hh
+++ b/about.hh
@@ -7,20 +7,6 @@
 #include "ui_about.h"
 #include <QDialog>
 
-// Microsoft Visual C++ version
-#if defined (_MSC_VER)
-   // how many digits does the build number have?
-#  if _MSC_FULL_VER / 10000 == _MSC_VER
-#    define GD_CXX_MSVC_BUILD (_MSC_FULL_VER % 10000)  // four digits
-#  elif _MSC_FULL_VER / 100000 == _MSC_VER
-#    define GD_CXX_MSVC_BUILD (_MSC_FULL_VER % 100000) // five digits
-#  else
-#    define GD_CXX_MSVC_BUILD 0
-#  endif
-#  define GD_CXX_MSVC_MAJOR (_MSC_VER/100-6)
-#  define GD_CXX_MSVC_MINOR (_MSC_VER%100)
-#endif
-
 class About: public QDialog
 {
   Q_OBJECT


### PR DESCRIPTION
the _MSC_VER and VS version has no direct and sound connection.

the existed code is incorrect.  `define GD_CXX_MSVC_MAJOR (_MSC_VER/100-6)` , only correct before VS2013
https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170&viewFallbackFrom=vs-2017

![image](https://user-images.githubusercontent.com/105986/170489405-c5b58953-e8a4-452b-b1bb-d9fe15c515cd.png)

just simply output the _MSC_FULL_VER . it is only useful to developers.
