### PR TITLE
ArticleView: expose only minimal API to JavaScript

### DIFF
--- a/articleview.hh
+++ b/articleview.hh
@@ -15,6 +15,7 @@
 #include "groupcombobox.hh"
 #include "ui_articleview.h"
 
+class ArticleViewJsProxy;
 class ResourceToSaveHandler;
 
 /// A widget with the web view tailored to view and handle articles -- it
@@ -31,6 +32,8 @@ class ArticleView: public QFrame
   Config::Class const & cfg;
 
   Ui::ArticleView ui;
+
+  ArticleViewJsProxy * const jsProxy;
 
   QAction pasteAction, articleUpAction, articleDownAction,
           goBackAction, goForwardAction, selectCurrentArticleAction,


### PR DESCRIPTION
https://doc.qt.io/archives/qt-5.5/qtwebkit-bridge.html#internet-security
Qt WebKit Bridge documentation recommends:
>  When exposing native objects to an open web environment, it is
  important to understand the security implications. Think whether the
  exposed object enables the web environment access things that
  shouldn't be open, and whether the web content loaded by that web page
  comes from a trusted source.

The author of Qt WebChannel has said the following in a talk that
introduced this Qt module (WebKit Bridge replacement for Qt WebEngine):
>  My suggestion here is to write dedicated QObjects with a slim, minimal
  API that only have the signals and methods that you deem safe to be
  used from the outside.
- see a comment under https://redirect.invidious.io/watch?v=KnvnTi6XafA