### PR TITLE
Don't update pages history in ArticleView::setCurrentArticle()

### DIFF
--- a/articleview.cc
+++ b/articleview.cc
@@ -761,10 +761,6 @@ bool ArticleView::setCurrentArticle( QString const & id, bool moveToIt )
   if ( moveToIt )
     ui.definition->page()->mainFrame()->evaluateJavaScript( QString( "document.getElementById('%1').scrollIntoView(true);" ).arg( id ) );
 
-  QMap< QString, QVariant > userData = ui.definition->history()->currentItem().userData().toMap();
-  userData[ "currentArticle" ] = id;
-  ui.definition->history()->currentItem().setUserData( userData );
-
   ui.definition->page()->mainFrame()->evaluateJavaScript(
     QString( "gdMakeArticleActive( '%1' );" ).arg( dictionaryId ) );
 


### PR DESCRIPTION
The current article is saved to pages history user data before any navigation to another page and before reloading the current page. Therefore saving it each time the user activates an article is redundant. This redundancy is not consistent, because when a user activates an article by clicking on it, the current article changes in the UI, but is not immediately saved in history as `setCurrentArticle()` is not called. The inconsistent redundancy is a waste of CPU time and can hide bugs.