### PR TITLE
Restart search when case sensitivity changes

### DIFF
--- a/articleview.cc
+++ b/articleview.cc
@@ -2285,7 +2285,7 @@ void ArticleView::on_searchCloseButton_clicked()
 
 void ArticleView::on_searchCaseSensitive_clicked()
 {
-  performFindOperation( false, false, true );
+  performFindOperation( true, false );
 }
 
 void ArticleView::on_highlightAllButton_clicked()


### PR DESCRIPTION
One issue with the current implementation is that a wrong-cased match
remains selected when the user checks the *Case Sensitive* checkbox.
Another issue is that the `noResults` property of `searchText` is not
updated right away, which means that `searchText`'s background color
remains wrong until next search.

Handle toggling case sensitivity in the same way as editing the searched
text: restart search from the beginning of the page. This improves the
Search-in-page UI consistency.