### PR TITLE
Don't replace previously searched-for text with title

### DIFF
--- a/articleview.cc
+++ b/articleview.cc
@@ -2233,7 +2233,8 @@ void ArticleView::openSearch()
   if ( !searchIsOpened )
   {
     ui.searchFrame->show();
-    ui.searchText->setText( getTitle() );
+    if( ui.searchText->text().isEmpty() )
+      ui.searchText->setText( getTitle() );
     searchIsOpened = true;
   }
 


### PR DESCRIPTION
The current page title is not a likely search term, seeing as it occurs
in many places all over the page. The user is more likely to search for
the phrase that was last searched for.