### PR TITLE
Forvo: add gender parameter

### DIFF
--- a/config.cc
+++ b/config.cc
@@ -702,6 +702,7 @@ Class load() THROW_SPEC( exError )
 
     c.forvo.apiKey = forvo.namedItem( "apiKey" ).toElement().text();
     c.forvo.languageCodes = forvo.namedItem( "languageCodes" ).toElement().text();
+    c.forvo.gender = Forvo::Gender( forvo.namedItem( "gender" ).toElement().text().toUInt() );
   }
   else
     c.forvo.languageCodes = "en, ru"; // Default demo values
@@ -1487,6 +1488,10 @@ void save( Class const & c ) THROW_SPEC( exError )
 
     opt = dd.createElement( "languageCodes" );
     opt.appendChild( dd.createTextNode( c.forvo.languageCodes ) );
+    forvo.appendChild( opt );
+
+    opt = dd.createElement( "gender" );
+    opt.appendChild( dd.createTextNode( QString::number( c.forvo.gender ) ) );
     forvo.appendChild( opt );
   }
 

--- a/config.hh
+++ b/config.hh
@@ -552,6 +552,12 @@ struct Forvo
   bool enable;
   QString apiKey;
   QString languageCodes;
+  enum Gender
+  {
+    Any = 0,
+    Male,
+    Female
+  } gender;
 
   Forvo(): enable( false )
   {}
@@ -559,7 +565,8 @@ struct Forvo
   bool operator == ( Forvo const & other ) const
   { return enable == other.enable &&
            apiKey == other.apiKey &&
-           languageCodes == other.languageCodes;
+           languageCodes == other.languageCodes &&
+           gender == other.gender;
   }
 
   bool operator != ( Forvo const & other ) const

--- a/forvo.hh
+++ b/forvo.hh
@@ -41,7 +41,7 @@ class ForvoArticleRequest: public Dictionary::DataRequest
 
   typedef std::list< NetReply > NetReplies;
   NetReplies netReplies;
-  QString apiKey, languageCode;
+  QString apiKey, languageCode, genderCode;
   string dictionaryId;
 
 public:
@@ -49,6 +49,7 @@ public:
   ForvoArticleRequest( wstring const & word, vector< wstring > const & alts,
                        QString const & apiKey_,
                        QString const & languageCode_,
+                       QString const & genderCode_,
                        string const & dictionaryId_,
                        QNetworkAccessManager & mgr );
 

--- a/sources.cc
+++ b/sources.cc
@@ -117,6 +117,10 @@ Sources::Sources( QWidget * parent, Config::Class const & cfg):
   ui.forvoEnabled->setChecked( forvo.enable );
   ui.forvoApiKey->setText( forvo.apiKey );
   ui.forvoLanguageCodes->setText( forvo.languageCodes );
+  ui.forvoGender->addItem( tr( "Any" ) );
+  ui.forvoGender->addItem( tr( "Male" ) );
+  ui.forvoGender->addItem( tr( "Female" ) );
+  ui.forvoGender->setCurrentIndex( forvo.gender );
 
   // Text to speech
 #if defined( Q_OS_WIN32 ) || defined( Q_OS_MAC )
@@ -383,6 +387,7 @@ Config::Forvo Sources::getForvo() const
   forvo.enable = ui.forvoEnabled->isChecked();
   forvo.apiKey = ui.forvoApiKey->text();
   forvo.languageCodes = ui.forvoLanguageCodes->text();
+  forvo.gender = Config::Forvo::Gender( ui.forvoGender->currentIndex() );
 
   return forvo;
 }

--- a/sources.ui
+++ b/sources.ui
@@ -609,6 +609,29 @@ in the future, or register on the site to get your own key.</string>
               </property>
              </spacer>
             </item>
+            <item row="5" column="0">
+             <spacer name="verticalSpacer_13">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="6" column="0">
+             <widget class="QLabel" name="label_17">
+              <property name="text">
+               <string>Gender:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="6" column="1">
+             <widget class="QComboBox" name="forvoGender"/>
+            </item>
            </layout>
           </item>
           <item>


### PR DESCRIPTION
Support filtering pronunciation by gender:
![scr0](https://user-images.githubusercontent.com/688044/176146660-4ac63a98-f538-4085-8cc9-60421cbe5a73.jpg)
See [Forvo API documentation](https://api.forvo.com/documentation/word-pronunciations/)