### PR TITLE
Revert "Replace a fruitless check with an assertion"

### DIFF
--- a/articleview.cc
+++ b/articleview.cc
@@ -2597,9 +2597,12 @@ void ArticleView::highlightFTSResults()
   sptr< AccentMarkHandler > marksHandler = ignoreDiacritics ?
                                            new DiacriticsHandler : new AccentMarkHandler;
 
-  // The code below relies on empty current selection. There must be no selection because this
-  // function is called only in one place - when a page loading finishes.
-  Q_ASSERT( !ui.definition->hasSelection() );
+  // Clear any current selection
+  if ( ui.definition->selectedText().size() )
+  {
+    ui.definition->page()->currentFrame()->
+           evaluateJavaScript( "window.getSelection().removeAllRanges();_=0;" );
+  }
 
   QString pageText = ui.definition->page()->currentFrame()->toPlainText();
   marksHandler->setText( pageText );


### PR DESCRIPTION
The assertion failure can be triggered by full-text-searching for a
common word, selecting a result with many large articles and quickly
selecting text in the first article while the page is still loading.

This reverts commit c936d03fa05ba6a726724cfe5208cd99ad57f3a0.