### PR TITLE
Show current match and match count during FTS result navigation

### DIFF
--- a/articleview.ui
+++ b/articleview.ui
@@ -94,6 +94,9 @@
        </widget>
       </item>
       <item>
+       <widget class="QLabel" name="ftsSearchStatusLabel"/>
+      </item>
+      <item>
        <spacer name="horizontalSpacer_2">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
This information is going to be especially useful in the upcoming Qt
WebEngine version of GoldenDict. In the Qt WebEngine version only the
words equal to the last found result can be highlighted, not all FTS
matches as in the Qt WebKit version.