### PR TITLE
Make saving complete article work in Qt 5.15

### DIFF
--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -3585,7 +3585,8 @@ void MainWindow::on_saveArticle_triggered()
                                            filters.join( ";;" ),
                                            &selectedFilter, options );
 
-  bool complete = ( selectedFilter == filters[ 0 ] );
+  // The " (*.html)" part of filters[i] is absent from selectedFilter in Qt 5.
+  bool const complete = filters.at( 0 ).startsWith( selectedFilter );
 
   if ( !fileName.isEmpty() )
   {


### PR DESCRIPTION
The old code works correctly in Qt 4.8.7. But in Qt 5.15.5 `selectedFilter` is never equal to either element of `filters`. So *HTML Only* is saved no matter which option the user selects.