### PR TITLE
Don't percent-encode local file names while saving an article

### DIFF
--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -3528,7 +3528,7 @@ static void filterAndCollectResources( QString & html, QRegExp & rx, const QStri
   {
     QUrl url( rx.cap( 1 ) );
     QString host = url.host();
-    QString resourcePath = QString::fromLatin1( QUrl::toPercentEncoding( Qt4x5::Url::path( url ), "/" ) );
+    QString resourcePath = Qt4x5::Url::path( url );
 
     if ( !host.startsWith( '/' ) )
       host.insert( 0, '/' );
@@ -3545,6 +3545,7 @@ static void filterAndCollectResources( QString & html, QRegExp & rx, const QStri
     }
 
     // Modify original url, set to the native one
+    resourcePath = QString::fromLatin1( QUrl::toPercentEncoding( resourcePath, "/" ) );
     QString newUrl = sep + QDir( folder ).dirName() + host + resourcePath + sep;
     html.replace( pos, rx.cap().length(), newUrl );
     pos += newUrl.length();


### PR DESCRIPTION
This commit fixes broken links in complete saved articles to files whose names contain reserved characters. An HTML parser decodes a percent-encoded URL before looking for the referenced file on disk. So a file with a percent-encoded name cannot be found. Percent-encode only the URL to fix the bug.