### PR TITLE
git clone URL in README: git:// => https:// scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This code has been run and tested on Windows XP/Vista/7, Ubuntu Linux, Mac OS X.
 
 First, clone this repository, e.g.:
 
-    git clone git://github.com/goldendict/goldendict.git
+    git clone https://github.com/goldendict/goldendict.git
 
 And then invoke `qmake-qt4` and `make`:
 


### PR DESCRIPTION
An attempt to clone the git:// URL fails on my Manjaro GNU/Linux system and produces the following output:
```
    $ git clone git://github.com/goldendict/goldendict.git
    Cloning into 'goldendict'...
    fatal: unable to connect to github.com:
    github.com[0: 140.82.121.4]: errno=Connection timed out

    128✗
```

The GitHub UI offers the replacement https:// URL when the green Code button in the GoldenDict repository is clicked.

Fixes #1561.