### PR TITLE
Don't attempt to translate empty or whitespace-only text

### DIFF
--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -2343,7 +2343,10 @@ void MainWindow::updateSuggestionList( QString const & newValue )
 
 void MainWindow::translateInputFinished( bool checkModifiers )
 {
-  QString word = Folding::unescapeWildcardSymbols( translateLine->text() );
+  QString word = translateLine->text().trimmed();
+  if( word.isEmpty() )
+    return;
+  word = Folding::unescapeWildcardSymbols( word );
   respondToTranslationRequest( Config::InputPhrase( word, translateBoxSuffix ), checkModifiers );
 }
 

--- a/scanpopup.cc
+++ b/scanpopup.cc
@@ -805,7 +805,10 @@ void ScanPopup::updateSuggestionList( QString const & text )
 
 void ScanPopup::translateInputFinished()
 {
-  inputPhrase.phrase = Folding::unescapeWildcardSymbols( ui.translateBox->translateLine()->text().trimmed() );
+  QString const word = ui.translateBox->translateLine()->text().trimmed();
+  if( word.isEmpty() )
+    return;
+  inputPhrase.phrase = Folding::unescapeWildcardSymbols( word );
   inputPhrase.punctuationSuffix = translateBoxSuffix;
   showTranslationFor( inputPhrase );
 }


### PR DESCRIPTION
Silently ignore empty or whitespace-only translation requests. It should be clear to most users why GoldenDict ignores them.

The translated word ends up as the "word" URL query item value, which is trimmed in `ArticleNetworkAccessManager::getResource()`. So the added trimming in `MainWindow::translateInputFinished()` should be fine.

When a trimmed translated word was empty, `InputPhrase::isValid()` returned false, `ArticleNetworkAccessManager::getResource()` returned a null pointer and `ArticleNetworkAccessManager::createRequest()` fell back to `QNetworkAccessManager::createRequest()`, which:
* failed silently in the Qt 4 version;
* displayed the
```
Protocol "gdlookup" is unknown
Failed to load URL gdlookup://localhost?word= &group=4.
QtNetwork Error 301
```
error page in the Qt 5 version.

Fixes #1179.