### PR TITLE
Don't append duplicates to openedInspectors

### DIFF
--- a/articleinspector.cc
+++ b/articleinspector.cc
@@ -47,7 +47,8 @@ void ArticleInspector::showEvent( QShowEvent * event )
     setGeometry( p->geometry() );
   }
 
-  openedInspectors.push_back( this );
+  if( std::find( openedInspectors.begin(), openedInspectors.end(), this ) == openedInspectors.end() )
+    openedInspectors.push_back( this );
 
   QWebInspector::showEvent( event );
 }


### PR DESCRIPTION
There is no benefit in storing the same pointer multiple times in `openedInspectors`. This occurred when an article inspector window was closed then shown again. When the tab corresponding to the duplicated article inspector pointer was closed, `ArticleInspector::beforeClosed()` erased only one pointer from `openedInspectors`. This left dangling duplicate pointer(s) in the list and eventually caused a crash when another inspector's `showEvent()` accessed a dangling pointer at `openedInspectors.front()`.