### PR TITLE
Download and open an image double-clicked in scan popup

### DIFF
--- a/articleview.cc
+++ b/articleview.cc
@@ -2320,7 +2320,7 @@ void ArticleView::doubleClicked( QPoint pos )
   QWebHitTestResult r = ui.definition->page()->mainFrame()->hitTestContent( pos );
   QWebElement el = r.element();
   QUrl imageUrl;
-  if( !popupView && el.tagName().compare( "img", Qt::CaseInsensitive ) == 0 )
+  if( el.tagName().compare( "img", Qt::CaseInsensitive ) == 0 )
   {
     // Double click on image; download it and transfer to external program
 


### PR DESCRIPTION
Now double-clicking an image has the same effect in the main window and in the scan popup. This consistency in no way prevents or hinders using the popup window as designed (for fast lookup in a small group of dictionaries), because a user is unlikely to double-click an image accidentally.

Without this commit, when "Double-click translates the word clicked" option is on, double-clicking an image in the scan popup translates currently selected text if the selection is not empty.

Fixes #1279.