### PR TITLE
Print debug output with gdDebug() instead of av_log()

### DIFF
--- a/ffmpegaudio.cc
+++ b/ffmpegaudio.cc
@@ -260,7 +260,7 @@ bool DecoderContext::openCodec( QString & errorString )
     return false;
   }
 
-  av_log( NULL, AV_LOG_INFO, "Codec open: %s: channels: %d, rate: %d, format: %s\n", codec_->long_name,
+  gdDebug( "Codec open: %s: channels: %d, rate: %d, format: %s\n", codec_->long_name,
           codecContext_->channels, codecContext_->sample_rate, av_get_sample_fmt_name( codecContext_->sample_fmt ) );
 
   if ( codecContext_->sample_fmt == AV_SAMPLE_FMT_S32  ||
@@ -363,7 +363,7 @@ bool DecoderContext::openOutputDevice( QString & errorString )
     return false;
   }
 
-  av_log( NULL, AV_LOG_INFO, "ao_open_live(): %s: channels: %d, rate: %d, bits: %d\n",
+  gdDebug( "ao_open_live(): %s: channels: %d, rate: %d, bits: %d\n",
           aoDrvInfo->name, aoSampleFormat.channels, aoSampleFormat.rate, aoSampleFormat.bits );
 
   aoDevice_ = ao_open_live( aoDriverId, &aoSampleFormat, NULL );


### PR DESCRIPTION
Users can enable or disable `av_log()` output only by inserting a call to `av_log_set_level()` and recompiling GoldenDict. Blink browser engine shipped with Qt WebEngine sets the log level to `AV_LOG_QUIET` in *chromium/media/base/media.cc* and thus disables all output. So GoldenDict's custom `AV_LOG_INFO` messages are always printed in the Qt WebKit version and never in the Qt WebEngine version.

In contrast, users have many ways to enable or disable `QDebug` output without recompilation since Qt 5. Furthermore, GoldenDict's command line option `--log-to-file` allows to redirect `gdDebug()` output to a log file.

The two messages printed via `av_log()` are clearly debug messages, because they are printed each time a word or a phrase is pronounced.