### PR TITLE
Disable GD_DPRINTF() output in Release builds on all systems

### DIFF
--- a/gddebug.hh
+++ b/gddebug.hh
@@ -4,11 +4,15 @@
 #include <QFile>
 
 #ifdef NO_CONSOLE
-#define GD_DPRINTF(...) do {} while( 0 )
-#define GD_FDPRINTF(...) do {} while( 0 )
+  #define GD_DPRINTF(...) do {} while( 0 )
+  #define GD_FDPRINTF(...) do {} while( 0 )
 #else
-#define GD_DPRINTF(...) printf(__VA_ARGS__)
-#define GD_FDPRINTF(...) fprintf(__VA_ARGS__)
+  #ifdef NO_GD_DPRINTF
+    #define GD_DPRINTF(...) do {} while( 0 )
+  #else
+    #define GD_DPRINTF(...) printf(__VA_ARGS__)
+  #endif
+  #define GD_FDPRINTF(...) fprintf(__VA_ARGS__)
 #endif
 
 void gdWarning(const char *, ...) /* print warning message */

--- a/goldendict.pro
+++ b/goldendict.pro
@@ -23,7 +23,7 @@ isEmpty( hasGit ) {
 }
 
 CONFIG( release, debug|release ) {
-  DEFINES += NDEBUG
+  DEFINES += NDEBUG NO_GD_DPRINTF
 }
 
 # DEPENDPATH += . generators


### PR DESCRIPTION
Defining `NO_CONSOLE` disables `GD_[F]DPRINTF()` output. The messages printed with `GD_DPRINTF()` are clearly debug messages. They flood GoldenDict's output with lines like these:

>     some body finished
>     one finished.
>     erasing..
>     erase done..
>     one not finished.
>     ====reading 16384 bytes

Messages printed to `stderr` with `GD_FDPRINTF()` are somewhat more interesting and less frequent, but still are not intended for end users, because they don't specify the problematic dictionary file or the error location in it. Plus GoldenDict should not expect end users to edit their dictionary files to correct minor issues. For example:
>    Warning: 1 tags were unclosed.