### PR TITLE
Demote missing favorites file message from warning to debug

### DIFF
--- a/favoritespanewidget.cc
+++ b/favoritespanewidget.cc
@@ -627,7 +627,7 @@ void FavoritesModel::readData()
   QFile favoritesFile( m_favoritesFilename );
   if( !favoritesFile.open( QFile::ReadOnly ) )
   {
-    gdWarning( "No favorities file found" );
+    gdDebug( "No favorites file found" );
     return;
   }
 


### PR DESCRIPTION
This file is never created if the Favorites feature is not used.

Fix a typo along the way: "favorities" => "favorites".