### PR TITLE
Demote input phrase limit message from warning to debug

### DIFF
--- a/config.cc
+++ b/config.cc
@@ -188,8 +188,8 @@ InputPhrase Preferences::sanitizeInputPhrase( QString const & inputPhrase ) cons
 
   if( limitInputPhraseLength && inputPhrase.size() > inputPhraseLengthLimit )
   {
-    gdWarning( "Ignoring an input phrase %d symbols long. The configured maximum input phrase length is %d symbols.",
-               inputPhrase.size(), inputPhraseLengthLimit );
+    gdDebug( "Ignoring an input phrase %d symbols long. The configured maximum input phrase length is %d symbols.",
+             inputPhrase.size(), inputPhraseLengthLimit );
     return result;
   }
 


### PR DESCRIPTION
Limiting input phrase length is disabled by default. The default length limit value is 1000. The user has to enable the option and lower the length limit in order to be surprised by missing translation. By making such configuration changes, the user should become aware of this feature and its effect.

As the person who has implemented this feature and uses 100 as the length limit, I am never surprised or disappointed by missing translation. The only annoyance is this warning that floods my systemd journal. Apparently I accidentally select overly long phrases way too often.