### PR TITLE
Show translateBoxWidget automatically when Words Zoom level decreases

### DIFF
--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -3948,8 +3948,13 @@ void MainWindow::applyWordsZoomLevel()
   }
 
   wordsZoomBase->setEnabled( cfg.preferences.wordsZoomLevel != 0 );
-  // groupList->setFixedHeight(translateLine->height());
-  groupList->parentWidget()->layout()->activate();
+
+  if( !cfg.preferences.searchInDock )
+  {
+    // Invalidating navToolbar's layout displays translateBoxWidget w/o the need to press the toolbar
+    // extension button when Words Zoom level decreases enough for translateBoxWidget to fit in the toolbar.
+    navToolbar->layout()->invalidate();
+  }
 
   if ( scanPopup.get() )
     scanPopup->applyWordsZoomLevel();


### PR DESCRIPTION
When Search Pane is hidden, Words Zoom level is large and GoldenDict main window's width is small, `translateBoxWidget` does not fit into the toolbar and is hidden behind the toolbar extension button **»** on the right side. Reducing Words Zoom level does not automatically make `translateBoxWidget` visible until the user presses the toolbar extension button or types text to be translated.

I haven't noticed any effect of the existing line of code that activates `groupList` parent widget's layout whether Search Pane is visible or hidden. This line was introduced in the commit that implemented `TranslateBox` - da139985183e7664b690c3c5482dcfaba7eeff22. In this initial implementation `navToolbar` was the parent of `groupList`, and `translateBoxWidget` did not yet exist. I think that the introduction of `translateBoxWidget` in 404a16442b45ff5129fe9e66b5672a21427bdc2f obsoleted this line of code, and so remove it here.

I have verified that this fix works as intended in the Qt 4 and the Qt 5 version both under KDE Plasma and Xfce.