### PR TITLE
Save&restore the geometry of Print Preview dialog

### DIFF
--- a/config.cc
+++ b/config.cc
@@ -1134,6 +1134,10 @@ Class load() THROW_SPEC( exError )
   if ( !dictionariesDialogGeometry.isNull() )
     c.dictionariesDialogGeometry = QByteArray::fromBase64( dictionariesDialogGeometry.toElement().text().toLatin1() );
 
+  QDomNode const printPreviewDialogGeometry = root.namedItem( "printPreviewDialogGeometry" );
+  if( !printPreviewDialogGeometry.isNull() )
+    c.printPreviewDialogGeometry = QByteArray::fromBase64( printPreviewDialogGeometry.toElement().text().toLatin1() );
+
   QDomNode timeForNewReleaseCheck = root.namedItem( "timeForNewReleaseCheck" );
 
   if ( !timeForNewReleaseCheck.isNull() )
@@ -2130,6 +2134,10 @@ void save( Class const & c ) THROW_SPEC( exError )
 
     opt = dd.createElement( "dictionariesDialogGeometry" );
     opt.appendChild( dd.createTextNode( QString::fromLatin1( c.dictionariesDialogGeometry.toBase64() ) ) );
+    root.appendChild( opt );
+
+    opt = dd.createElement( "printPreviewDialogGeometry" );
+    opt.appendChild( dd.createTextNode( QString::fromLatin1( c.printPreviewDialogGeometry.toBase64() ) ) );
     root.appendChild( opt );
 
     opt = dd.createElement( "timeForNewReleaseCheck" );

--- a/config.hh
+++ b/config.hh
@@ -678,6 +678,7 @@ struct Class
   QByteArray dictInfoGeometry; // Geometry of "Dictionary info" window
   QByteArray inspectorGeometry; // Geometry of WebKit inspector window
   QByteArray dictionariesDialogGeometry; // Geometry of Dictionaries dialog
+  QByteArray printPreviewDialogGeometry; // Geometry of Print Preview dialog
   QByteArray helpWindowGeometry; // Geometry of help window
   QByteArray helpSplitterState; // Geometry of help splitter
 

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -3545,13 +3545,15 @@ void MainWindow::on_pageSetup_triggered()
 
 void MainWindow::on_printPreview_triggered()
 {
-  QPrintPreviewDialog dialog( &getPrinter(), this );
+  QPrintPreviewDialog dialog( &getPrinter(), this,
+                              Qt::WindowSystemMenuHint | Qt::WindowMaximizeButtonHint | Qt::WindowCloseButtonHint );
+  dialog.restoreGeometry( cfg.printPreviewDialogGeometry );
 
   connect( &dialog, SIGNAL( paintRequested( QPrinter * ) ),
            this, SLOT( printPreviewPaintRequested( QPrinter * ) ) );
 
-  dialog.showMaximized();
   dialog.exec();
+  cfg.printPreviewDialogGeometry = dialog.saveGeometry();
 }
 
 void MainWindow::on_print_triggered()


### PR DESCRIPTION
The dialog appearance under Xfce before this commit: 
![print-preview-xfce-before](https://user-images.githubusercontent.com/5929075/202104645-f47313c6-5ec9-4aa4-9b07-2fd3c2eebf36.png)

The default dialog appearance under Xfce at this commit:
![print-preview-xfce-after](https://user-images.githubusercontent.com/5929075/202104721-66781235-4a2b-4ed5-ac2e-9f3007f71c61.png)

See the commit message for details.