### PR TITLE
Set article background to white while printing

### DIFF
--- a/article-style-print.css
+++ b/article-style-print.css
@@ -1,6 +1,6 @@
 /* This stylesheet is used for printing only, overriding article-style.css */
 
-body
+html, body, .gdarticle
 {
   background: white;
 }
@@ -11,4 +11,3 @@ body
 {
   display: none;
 }
-


### PR DESCRIPTION
cb6b00d85e29a017742831de16530fb8bc85ad8e set `.gdarticle background` to `#fefdeb` in *article-style.css*, but failed to override it in *article-style-print.css*.

Set `html` background to `white` as well in order to prevent a thin border around articles' contents if non-printing article styles set `html` background to a color other than white.

Printing color background makes little sense and is wasteful. Users who prefer the old behavior can override the background color in *\<Configuration Folder\>/article-style-print.css*.

Use `background` rather than `background-color` CSS property in order to overwrite any background image set by non-printing article styles.