### PR TITLE
Don't reset FTS Ignore* options on Preferences change

### DIFF
--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -2190,6 +2190,8 @@ void MainWindow::editPreferences()
     p.fts.searchMode = cfg.preferences.fts.searchMode;
     p.fts.useMaxArticlesPerDictionary = cfg.preferences.fts.useMaxArticlesPerDictionary;
     p.fts.useMaxDistanceBetweenWords = cfg.preferences.fts.useMaxDistanceBetweenWords;
+    p.fts.ignoreWordsOrder = cfg.preferences.fts.ignoreWordsOrder;
+    p.fts.ignoreDiacritics = cfg.preferences.fts.ignoreDiacritics;
 
     bool needReload = false;
 


### PR DESCRIPTION
Accepting changes in Preferences dialog no longer disables two options "Ignore words order" and "Ignore diacritics", which are configurable in Full-text search dialog.