### PR TITLE
Qt 5.14+: don't use deprecated QString::SkipEmptyParts

### DIFF
--- a/about.cc
+++ b/about.cc
@@ -44,7 +44,7 @@ About::About( QWidget * parent ): QDialog( parent )
   {
     QStringList creditsList =
       QString::fromUtf8(
-        creditsFile.readAll() ).split( '\n', QString::SkipEmptyParts );
+        creditsFile.readAll() ).split( '\n', Qt4x5::skipEmptyParts() );
 
     QString html = "<html><body style='color: black; background: #f4f4f4;'>";
 

--- a/articleview.cc
+++ b/articleview.cc
@@ -726,7 +726,7 @@ unsigned ArticleView::getGroup( QUrl const & url )
 QStringList ArticleView::getArticlesList()
 {
   return evaluateJavaScriptVariableSafe( ui.definition->page()->mainFrame(), "gdArticleContents" )
-      .toString().trimmed().split( ' ', QString::SkipEmptyParts );
+      .toString().trimmed().split( ' ', Qt4x5::skipEmptyParts() );
 }
 
 QString ArticleView::getActiveArticleId()
@@ -1214,7 +1214,7 @@ void ArticleView::openLink( QUrl const & url, QUrl const & ref,
     if( Qt4x5::Url::hasQueryItem( ref, "dictionaries" ) )
     {
       QStringList dictsList = Qt4x5::Url::queryItemValue( ref, "dictionaries" )
-                                          .split( ",", QString::SkipEmptyParts );
+                                          .split( ",", Qt4x5::skipEmptyParts() );
 
       showDefinition( url.path(), dictsList, QRegExp(), getGroup( ref ), false );
     }
@@ -1236,7 +1236,7 @@ void ArticleView::openLink( QUrl const & url, QUrl const & ref,
       {
         // Specific dictionary group from full-text search
         QStringList dictsList = Qt4x5::Url::queryItemValue( ref, "dictionaries" )
-                                            .split( ",", QString::SkipEmptyParts );
+                                            .split( ",", Qt4x5::skipEmptyParts() );
 
         showDefinition( url.path().mid( 1 ), dictsList, QRegExp(), getGroup( ref ), false );
         return;
@@ -2411,7 +2411,7 @@ void ArticleView::doubleClicked( QPoint pos )
         if( Qt4x5::Url::hasQueryItem( ref, "dictionaries" ) )
         {
           QStringList dictsList = Qt4x5::Url::queryItemValue(ref, "dictionaries" )
-                                              .split( ",", QString::SkipEmptyParts );
+                                              .split( ",", Qt4x5::skipEmptyParts() );
           showDefinition( selectedText, dictsList, QRegExp(), getGroup( ref ), false );
         }
         else

--- a/dictserver.cc
+++ b/dictserver.cc
@@ -202,11 +202,11 @@ public:
     if( pos < 0 )
       url = "dict://" + url;
 
-    databases = database_.split( QRegExp( "[ ,;]" ), QString::SkipEmptyParts );
+    databases = database_.split( QRegExp( "[ ,;]" ), Qt4x5::skipEmptyParts() );
     if( databases.isEmpty() )
       databases.append( "*" );
 
-    strategies = strategies_.split( QRegExp( "[ ,;]" ), QString::SkipEmptyParts );
+    strategies = strategies_.split( QRegExp( "[ ,;]" ), Qt4x5::skipEmptyParts() );
     if( strategies.isEmpty() )
       strategies.append( "prefix" );
   }

--- a/epwing_book.cc
+++ b/epwing_book.cc
@@ -555,7 +555,7 @@ bool EpwingBook::setSubBook( int book_nom )
     QString line = ts.readLine();
     while( !line.isEmpty() )
     {
-      QStringList list = line.remove( '\n' ).split( ' ', QString::SkipEmptyParts );
+      QStringList list = line.remove( '\n' ).split( ' ', Qt4x5::skipEmptyParts() );
       if( list.count() == 2 )
         customFontsMap[ list[ 0 ] ] = list[ 1 ];
       line = ts.readLine();

--- a/favoritespanewidget.cc
+++ b/favoritespanewidget.cc
@@ -15,6 +15,7 @@
 #include "favoritespanewidget.hh"
 #include "gddebug.hh"
 #include "atomic_rename.hh"
+#include "qt4x5.hh"
 
 /************************************************** FavoritesPaneWidget *********************************************/
 
@@ -976,7 +977,7 @@ bool FavoritesModel::addNewHeadword( const QString & path, const QString & headw
 
   // Find or create target folder
 
-  QStringList folders = path.split( "/", QString::SkipEmptyParts );
+  QStringList folders = path.split( "/", Qt4x5::skipEmptyParts() );
   QStringList::const_iterator it = folders.begin();
   for( ; it != folders.end(); ++it )
     parentIdx = forceFolder( *it, parentIdx );
@@ -992,7 +993,7 @@ bool FavoritesModel::removeHeadword( const QString & path, const QString & headw
 
   // Find target folder
 
-  QStringList folders = path.split( "/", QString::SkipEmptyParts );
+  QStringList folders = path.split( "/", Qt4x5::skipEmptyParts() );
   QStringList::const_iterator it = folders.begin();
   for( ; it != folders.end(); ++it )
   {
@@ -1022,7 +1023,7 @@ bool FavoritesModel::isHeadwordPresent( const QString & path, const QString & he
 
   // Find target folder
 
-  QStringList folders = path.split( "/", QString::SkipEmptyParts );
+  QStringList folders = path.split( "/", Qt4x5::skipEmptyParts() );
   QStringList::const_iterator it = folders.begin();
   for( ; it != folders.end(); ++it )
   {

--- a/forvo.cc
+++ b/forvo.cc
@@ -378,7 +378,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries(
 
   if ( forvo.enable )
   {
-    QStringList codes = forvo.languageCodes.split( ',', QString::SkipEmptyParts );
+    QStringList codes = forvo.languageCodes.split( ',', Qt4x5::skipEmptyParts() );
 
     QSet< QString > usedCodes;
 

--- a/ftshelpers.cc
+++ b/ftshelpers.cc
@@ -93,17 +93,17 @@ bool parseSearchString( QString const & str, QStringList & indexWords,
 
     // Make words list for search in article text
     searchWords = str.normalized( QString::NormalizationForm_C )
-                     .split( spacesRegExp, QString::SkipEmptyParts );
+                     .split( spacesRegExp, Qt4x5::skipEmptyParts() );
 
     // Make words list for index search
     QStringList list = str.normalized( QString::NormalizationForm_C )
-                          .toLower().split( spacesRegExp, QString::SkipEmptyParts );
+                          .toLower().split( spacesRegExp, Qt4x5::skipEmptyParts() );
     indexWords = list.filter( wordRegExp );
     indexWords.removeDuplicates();
 
     // Make regexp for results hilite
 
-    QStringList allWords = str.split( spacesRegExp, QString::SkipEmptyParts );
+    QStringList allWords = str.split( spacesRegExp, Qt4x5::skipEmptyParts() );
     QString searchString = makeHiliteRegExpString( allWords, searchMode, distanceBetweenWords );
 
     searchRegExp = QRegExp( searchString, matchCase ? Qt::CaseSensitive : Qt::CaseInsensitive,
@@ -126,7 +126,7 @@ bool parseSearchString( QString const & str, QStringList & indexWords,
     tmp.replace( setsRegExp, " " );
 
     QStringList list = tmp.normalized( QString::NormalizationForm_C )
-                          .toLower().split( spacesRegExp, QString::SkipEmptyParts );
+                          .toLower().split( spacesRegExp, Qt4x5::skipEmptyParts() );
 
     if( hasCJK )
     {
@@ -192,13 +192,13 @@ void parseArticleForFts( uint32_t articleAddress, QString & articleText,
   QStringList articleWords = articleText.normalized( QString::NormalizationForm_C )
                                         .split( QRegularExpression( handleRoundBrackets ? "[^\\w\\(\\)\\p{M}]+" : "[^\\w\\p{M}]+",
                                                                     QRegularExpression::UseUnicodePropertiesOption ),
-                                                QString::SkipEmptyParts );
+                                                Qt4x5::skipEmptyParts() );
 #else
   QRegExp regBrackets = QRegExp( "(\\(\\w+\\)){0,1}(\\w+)(\\(\\w+\\)){0,1}(\\w+){0,1}(\\(\\w+\\)){0,1}" );
   QRegExp regSplit = QRegExp( "\\W+" );
 
   QStringList articleWords = articleText.normalized( QString::NormalizationForm_C )
-                                        .split( QRegExp( handleRoundBrackets ? "[^\\w\\(\\)]+" : "\\W+" ), QString::SkipEmptyParts );
+                                        .split( QRegExp( handleRoundBrackets ? "[^\\w\\(\\)]+" : "\\W+" ), Qt4x5::skipEmptyParts() );
 #endif
 
   QSet< QString > setOfWords;
@@ -242,7 +242,7 @@ void parseArticleForFts( uint32_t articleAddress, QString & articleText,
         // Special handle for words with round brackets - DSL feature
         QStringList list;
 
-        QStringList oldVariant = word.split( regSplit, QString::SkipEmptyParts );
+        QStringList oldVariant = word.split( regSplit, Qt4x5::skipEmptyParts() );
         for( QStringList::iterator it = oldVariant.begin(); it != oldVariant.end(); ++it )
           if( it->size() >= FTS::MinimumWordSize && !list.contains( *it ) )
             list.append( *it );
@@ -540,7 +540,7 @@ void FTSResultsRequest::checkArticles( QVector< uint32_t > const & offsets,
         articleText = gd::toQString( Folding::applyDiacriticsOnly( gd::toWString( articleText ) ) );
 
       QStringList articleWords = articleText.split( needHandleBrackets ? splitWithBrackets : splitWithoutBrackets,
-                                                    QString::SkipEmptyParts );
+                                                    Qt4x5::skipEmptyParts() );
 
       int wordsNum = articleWords.length();
       while ( pos < wordsNum )
@@ -577,7 +577,7 @@ void FTSResultsRequest::checkArticles( QVector< uint32_t > const & offsets,
               parsedWords.append( word );
             }
             else
-              parsedWords = s.split( regSplit, QString::SkipEmptyParts );
+              parsedWords = s.split( regSplit, Qt4x5::skipEmptyParts() );
           }
           else
             parsedWords.append( s );

--- a/programs.cc
+++ b/programs.cc
@@ -353,7 +353,7 @@ void ProgramWordSearchRequest::instanceFinished( QByteArray output, QString erro
     // Handle any Windows artifacts
     output.replace( "\r\n", "\n" );
     QStringList result =
-      QString::fromUtf8( output ).split( "\n", QString::SkipEmptyParts );
+      QString::fromUtf8( output ).split( "\n", Qt4x5::skipEmptyParts() );
 
     for( int x = 0; x < result.size(); ++x )
       matches.push_back( Dictionary::WordMatch( gd::toWString( result[ x ] ) ) );

--- a/qt4x5.hh
+++ b/qt4x5.hh
@@ -21,6 +21,14 @@
 namespace Qt4x5
 {
 
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 14, 0 )
+inline Qt::SplitBehaviorFlags skipEmptyParts()
+{ return Qt::SkipEmptyParts; }
+#else
+inline QString::SplitBehavior skipEmptyParts()
+{ return QString::SkipEmptyParts; }
+#endif
+
 inline QString escape( QString const & plain )
 {
 #if IS_QT_5

--- a/stardict.cc
+++ b/stardict.cc
@@ -714,7 +714,7 @@ void StardictDictionary::pangoToHtml( QString & text )
           {
             // Parse font description
 
-            QStringList list = styleRegex.cap( 2 ).split( " ", QString::SkipEmptyParts );
+            QStringList list = styleRegex.cap( 2 ).split( " ", Qt4x5::skipEmptyParts() );
             int n;
             QString sizeStr, stylesStr, familiesStr;
             for( n = list.size() - 1; n >= 0; n-- )


### PR DESCRIPTION
This change fixes the following GCC warnings:
```
warning: ‘QString::SkipEmptyParts’ is deprecated [-Wdeprecated-declarations]
warning: ‘QStringList QString::split(const QString&, SplitBehavior, Qt::CaseSensitivity) const’ is deprecated: Use split(const QString &sep, Qt::SplitBehavior ...) variant instead [-Wdeprecated-declarations]
warning: ‘QStringList QString::split(QChar, SplitBehavior, Qt::CaseSensitivity) const’ is deprecated: Use split(QChar sep, Qt::SplitBehavior ...) variant instead [-Wdeprecated-declarations]
warning: ‘QStringList QString::split(const QRegExp&, SplitBehavior) const’ is deprecated: Use split(const QRegularExpression &, Qt::SplitBehavior) variant instead [-Wdeprecated-declarations]
warning: ‘QStringList QString::split(const QRegularExpression&, SplitBehavior) const’ is deprecated: Use split(const QRegularExpression &, Qt::SplitBehavior) variant instead [-Wdeprecated-declarations]
```