### PR TITLE
Port away from deprecated Qt API

### DIFF
--- a/aard.cc
+++ b/aard.cc
@@ -960,8 +960,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries(
           quint16 volumes = qFromBigEndian( dictHeader.totalVolumes );
           if( volumes > 1 )
           {
-            QString ss;
-            ss.sprintf( " (%i/%i)", qFromBigEndian( dictHeader.volume ), volumes );
+            QString const ss = QString( " (%1/%2)" ).arg( qFromBigEndian( dictHeader.volume ) ).arg( volumes );
             dictName += ss.toLocal8Bit().data();
           }
 

--- a/article_netmgr.cc
+++ b/article_netmgr.cc
@@ -357,7 +357,9 @@ QNetworkReply * ArticleNetworkAccessManager::createRequest( Operation op,
   // spoof User-Agent
   if ( hideGoldenDictHeader && localReq.url().scheme().startsWith("http", Qt::CaseInsensitive))
   {
-    localReq.setRawHeader("User-Agent", localReq.rawHeader("User-Agent").replace(qApp->applicationName(), ""));
+    QByteArray const userAgentHeader = "User-Agent";
+    localReq.setRawHeader( userAgentHeader,
+                           localReq.rawHeader( userAgentHeader ).replace( qApp->applicationName().toUtf8(), "" ) );
     reply = QNetworkAccessManager::createRequest( op, localReq, outgoingData );
   }
 

--- a/article_netmgr.cc
+++ b/article_netmgr.cc
@@ -418,8 +418,12 @@ sptr< Dictionary::DataRequest > ArticleNetworkAccessManager::getResource(
 
     // See if we have some dictionaries muted
 
-    QSet< QString > mutedDicts =
-        QSet< QString >::fromList( Qt4x5::Url::queryItemValue( url, "muted" ).split( ',' ) );
+    QStringList const mutedDictList = Qt4x5::Url::queryItemValue( url, "muted" ).split( ',' );
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 14, 0 )
+    QSet< QString > const mutedDicts( mutedDictList.cbegin(), mutedDictList.cend() );
+#else
+    QSet< QString > const mutedDicts = QSet< QString >::fromList( mutedDictList );
+#endif
 
     // Unpack contexts
 

--- a/article_netmgr.cc
+++ b/article_netmgr.cc
@@ -180,7 +180,11 @@ using std::string;
   void AllowFrameReply::applyError( QNetworkReply::NetworkError code )
   {
     setError( code, baseReply->errorString() );
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 15, 0 )
+    emit errorOccurred( code );
+#else
     emit error( code );
+#endif
   }
 
   void AllowFrameReply::readDataFromBase()
@@ -625,7 +629,13 @@ void ArticleResourceReply::readyReadSlot()
 void ArticleResourceReply::finishedSlot()
 {
   if ( req->dataSize() < 0 )
-    error( ContentNotFoundError );
+  {
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 15, 0 )
+    emit errorOccurred( ContentNotFoundError );
+#else
+    emit error( ContentNotFoundError );
+#endif
+  }
 
   finished();
 }

--- a/articleview.cc
+++ b/articleview.cc
@@ -569,7 +569,7 @@ void ArticleView::loadFinished( bool )
   {
     // There's some sort of glitch -- sometimes you need to move a mouse
 
-    QMouseEvent ev( QEvent::MouseMove, QPoint(), Qt::MouseButton(), 0, 0 );
+    QMouseEvent ev( QEvent::MouseMove, QPoint(), Qt::MouseButton(), Qt::MouseButtons(), Qt::KeyboardModifiers() );
 
     qApp->sendEvent( ui.definition, &ev );
   }
@@ -2438,7 +2438,7 @@ void ArticleView::performFindOperation( bool restart, bool backwards, bool check
       }
     }
 
-    QWebPage::FindFlags f( 0 );
+    QWebPage::FindFlags f;
 
     if ( ui.searchCaseSensitive->isChecked() )
       f |= QWebPage::FindCaseSensitively;
@@ -2455,7 +2455,7 @@ void ArticleView::performFindOperation( bool restart, bool backwards, bool check
       return;
   }
 
-  QWebPage::FindFlags f( 0 );
+  QWebPage::FindFlags f;
 
   if ( ui.searchCaseSensitive->isChecked() )
     f |= QWebPage::FindCaseSensitively;
@@ -2508,7 +2508,7 @@ bool ArticleView::closeSearch()
     ui.ftsSearchFrame->hide();
     ui.definition->setFocus();
 
-    QWebPage::FindFlags flags ( 0 );
+    QWebPage::FindFlags flags;
 
   #if QT_VERSION >= 0x040600
     flags |= QWebPage::HighlightAllOccurrences;
@@ -2676,7 +2676,7 @@ void ArticleView::highlightFTSResults()
 
   ftsSearchMatchCase = Qt4x5::Url::hasQueryItem( url, "matchcase" );
 
-  QWebPage::FindFlags flags ( 0 );
+  QWebPage::FindFlags flags;
 
   if( ftsSearchMatchCase )
     flags |= QWebPage::FindCaseSensitively;
@@ -2737,7 +2737,7 @@ void ArticleView::performFtsFindOperation( bool backwards )
     return;
   }
 
-  QWebPage::FindFlags flags( 0 );
+  QWebPage::FindFlags flags;
 
   if( ftsSearchMatchCase )
     flags |= QWebPage::FindCaseSensitively;

--- a/articleview.cc
+++ b/articleview.cc
@@ -159,7 +159,7 @@ public:
 
     for( size_t left = baseText.size(); left; )
     {
-      if( *nextChar >= 0x10000U )
+      if( *nextChar >= 0x10000 )
       {
         // Will be translated into surrogate pair
         normText.push_back( *nextChar );

--- a/articleview.cc
+++ b/articleview.cc
@@ -980,15 +980,15 @@ bool ArticleView::eventFilter( QObject * obj, QEvent * ev )
 
         QWidget *child = widget->childAt( widget->mapFromGlobal( pt ) );
         if( child )
-        {
-          QWheelEvent whev( child->mapFromGlobal( pt ), pt, delta, Qt::NoButton, Qt::NoModifier );
-          qApp->sendEvent( child, &whev );
-        }
-        else
-        {
-          QWheelEvent whev( widget->mapFromGlobal( pt ), pt, delta, Qt::NoButton, Qt::NoModifier );
-          qApp->sendEvent( widget, &whev );
-        }
+          widget = child;
+
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 12, 0 )
+        QWheelEvent whev( widget->mapFromGlobal( pt ), pt, QPoint(), QPoint( 0, delta ),
+                          Qt::NoButton, Qt::NoModifier, Qt::NoScrollPhase, false );
+#else
+        QWheelEvent whev( widget->mapFromGlobal( pt ), pt, delta, Qt::NoButton, Qt::NoModifier );
+#endif
+        qApp->sendEvent( widget, &whev );
       }
     }
 

--- a/articlewebview.cc
+++ b/articlewebview.cc
@@ -6,6 +6,7 @@
 #include <QWebFrame>
 #include <QApplication>
 #include "articleinspector.hh"
+#include "qt4x5.hh"
 
 #ifdef Q_OS_WIN32
 #include <qt_windows.h>
@@ -85,7 +86,7 @@ bool ArticleWebView::event( QEvent * event )
 
 void ArticleWebView::mousePressEvent( QMouseEvent * event )
 {
-  if ( event->buttons() & Qt::MidButton )
+  if ( event->buttons() & Qt4x5::middleButton() )
     midButtonPressed = true;
 
   QWebView::mousePressEvent( event );
@@ -100,7 +101,7 @@ void ArticleWebView::mousePressEvent( QMouseEvent * event )
 
 void ArticleWebView::mouseReleaseEvent( QMouseEvent * event )
 {
-  bool noMidButton = !( event->buttons() & Qt::MidButton );
+  bool noMidButton = !( event->buttons() & Qt4x5::middleButton() );
 
   QWebView::mouseReleaseEvent( event );
 

--- a/btreeidx.cc
+++ b/btreeidx.cc
@@ -1472,8 +1472,9 @@ void BtreeIndex::getHeadwordsFromOffsets( QList<uint32_t> & offsets,
 
   // Read all chains
 
-  QList< uint32_t >::Iterator begOffsets = offsets.begin();
-  QList< uint32_t >::Iterator endOffsets = offsets.end();
+  typedef QList< uint32_t >::Iterator ListIterator;
+  ListIterator begOffsets = offsets.begin();
+  ListIterator endOffsets = offsets.end();
 
   for( ; ; )
   {
@@ -1481,16 +1482,16 @@ void BtreeIndex::getHeadwordsFromOffsets( QList<uint32_t> & offsets,
 
     for( unsigned i = 0; i < result.size(); i++ )
     {
-      QList< uint32_t >::Iterator it = qBinaryFind( begOffsets, endOffsets,
-                                                    result.at( i ).articleOffset );
+      std::pair< ListIterator, ListIterator > const range = std::equal_range( begOffsets, endOffsets,
+                                                                              result.at( i ).articleOffset );
 
-      if( it != offsets.end() )
+      if( range.first != range.second )
       {
         if( isCancelled && Qt4x5::AtomicInt::loadAcquire( *isCancelled ) )
           return;
 
         headwords.append(  QString::fromUtf8( ( result[ i ].prefix + result[ i ].word ).c_str() ) );
-        offsets.erase( it );
+        offsets.erase( range.first );
         begOffsets = offsets.begin();
         endOffsets = offsets.end();
       }

--- a/config.cc
+++ b/config.cc
@@ -97,7 +97,7 @@ ProxyServer::ProxyServer(): enabled( false ), useSystemProxy( false ), type( Soc
 {
 }
 
-HotKey::HotKey(): modifiers( 0 ), key1( 0 ), key2( 0 )
+HotKey::HotKey(): modifiers(), key1( 0 ), key2( 0 )
 {
 }
 

--- a/dictionarybar.cc
+++ b/dictionarybar.cc
@@ -6,6 +6,7 @@
 #include <QProcess>
 #include "gddebug.hh"
 #include "fsencoding.hh"
+#include "qt4x5.hh"
 #include <QDebug>
 
 using std::vector;
@@ -211,7 +212,7 @@ void DictionaryBar::showContextMenu( QContextMenuEvent * event, bool extended )
   {
     QString command( editDictionaryCommand );
     command.replace( "%GDDICT%", "\"" + dictFilename + "\"" );
-    if( !QProcess::startDetached( command ) )
+    if( !Qt4x5::Process::startDetached( command ) )
       QApplication::beep();
   }
 

--- a/epwing.cc
+++ b/epwing.cc
@@ -961,7 +961,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries(
 
   vector< string > dictFiles;
   QByteArray catName;
-  catName += QDir::separator();
+  catName += QDir::separator().toLatin1();
   catName += "catalogs";
 
   for( vector< string >::const_iterator i = fileNames.begin(); i != fileNames.end();

--- a/epwing_book.cc
+++ b/epwing_book.cc
@@ -1759,8 +1759,7 @@ QByteArray EpwingBook::handleReference( EB_Hook_Code code, const unsigned int * 
     if( refOpenCount > refCloseCount )
       return QByteArray();
 
-    QString str;
-    str.sprintf( "<R%i>", refOpenCount );
+    QString str = QString( "<R%1>" ).arg( refOpenCount );
     refOpenCount += 1;
     return str.toUtf8();
   }
@@ -1773,8 +1772,7 @@ QByteArray EpwingBook::handleReference( EB_Hook_Code code, const unsigned int * 
   refPages.append( argv[ 1 ] );
   refOffsets.append( argv[ 2 ] );
 
-  QString str;
-  str.sprintf( "</R%i>", refCloseCount );
+  QString str = QString( "</R%1>").arg( refCloseCount );
   refCloseCount += 1;
 
   return str.toUtf8();

--- a/extlineedit.cc
+++ b/extlineedit.cc
@@ -113,14 +113,10 @@ void ExtLineEdit::updateButtonPositions()
             iconPos = (iconPos == Left ? Right : Left);
 
         if (iconPos == ExtLineEdit::Right) {
-            int right;
-            getTextMargins(0, 0, &right, 0);
-            const int iconoffset = right + 4;
+            int const iconoffset = textMargins().right() + 4;
             iconButtons[i]->setGeometry(contentRect.adjusted(width() - iconoffset, 0, 0, 0));
         } else {
-            int left;
-            getTextMargins(&left, 0, 0, 0);
-            const int iconoffset = left + 4;
+            int const iconoffset = textMargins().left() + 4;
             iconButtons[i]->setGeometry(contentRect.adjusted(0, 0, -width() + iconoffset, 0));
         }
     }

--- a/favoritespanewidget.cc
+++ b/favoritespanewidget.cc
@@ -908,7 +908,16 @@ void FavoritesModel::removeItemsForIndexes( const QModelIndexList & idxList )
   for( int i = lowestLevel; i >= 0; i-- )
   {
     QModelIndexList idxSublist = itemsToDelete[ i ];
+#if __cplusplus >= 201103L
+    // Cannot simply use std::greater< QModelIndex >, because the necessary overload of operator> is missing:
+    // stl_function.h: error: no match for ‘operator>’ (operand types are ‘const QModelIndex’ and ‘const QModelIndex’)
+    // Deprecated qGreater function object template is implemented in terms of operator<, like the lambda below.
+    std::sort( idxSublist.begin(), idxSublist.end(), []( QModelIndex const & a, QModelIndex const & b ) {
+      return b < a;
+    } );
+#else
     std::sort( idxSublist.begin(), idxSublist.end(), qGreater< QModelIndex >() );
+#endif
 
     it = idxSublist.begin();
     for( ; it != idxSublist.end(); ++it )

--- a/gddebug.cc
+++ b/gddebug.cc
@@ -8,7 +8,11 @@
 #include "categorized_logging.hh"
 #include "gddebug.hh"
 
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 5, 0 )
+#define TO_LOG_MESSAGE( msg, ap ) QString::vasprintf( msg, ap ).toUtf8().constData()
+#else
 #define TO_LOG_MESSAGE( msg, ap ) QString().vsprintf( msg, ap ).toUtf8().constData()
+#endif
 
 QFile * logFilePtr;
 

--- a/groups_widgets.cc
+++ b/groups_widgets.cc
@@ -734,16 +734,12 @@ void DictGroupsWidget::addAutoGroups()
       if( fileName.endsWith( ".aff", Qt::CaseInsensitive ) )
       {
         QString code = fileName.left( 2 ).toLower();
-        QVector<sptr<Dictionary::Class> > vd = morphoMap[ code ];
-        vd.append( dict );
-        morphoMap[ code ] = vd;
+        morphoMap[ code ].push_back( dict );
         continue;
       }
     }
 
-    QVector<sptr<Dictionary::Class> > vd = dictMap[ name ];
-    vd.append( dict );
-    dictMap[ name ] = vd;
+    dictMap[ name ].push_back( dict );
   }
 
   QStringList groupList = dictMap.uniqueKeys();

--- a/groups_widgets.cc
+++ b/groups_widgets.cc
@@ -742,8 +742,8 @@ void DictGroupsWidget::addAutoGroups()
     dictMap[ name ].push_back( dict );
   }
 
-  QStringList groupList = dictMap.uniqueKeys();
-  QStringList morphoList = morphoMap.uniqueKeys();
+  QStringList const groupList = dictMap.keys();
+  QStringList const morphoList = morphoMap.keys();
 
   // Insert morphology dictionaries into corresponding lists
 

--- a/helpwindow.cc
+++ b/helpwindow.cc
@@ -12,6 +12,10 @@
 #include "helpwindow.hh"
 #include "gddebug.hh"
 
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 15, 0 )
+#include <QHelpLink>
+#endif
+
 namespace Help {
 
 HelpBrowser::HelpBrowser( QHelpEngineCore * engine, QWidget *parent ) :
@@ -25,9 +29,15 @@ void HelpBrowser::showHelpForKeyword( QString const & id )
 {
   if ( helpEngine )
   {
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 15, 0 )
+    auto const links = helpEngine->documentsForIdentifier( id );
+    if( !links.empty() )
+      setSource( links.constFirst().url );
+#else
     QMap< QString, QUrl > links = helpEngine->linksForIdentifier( id );
     if( !links.isEmpty() )
       setSource( links.constBegin().value() );
+#endif
   }
 }
 

--- a/hotkeyedit.cc
+++ b/hotkeyedit.cc
@@ -10,7 +10,7 @@
 
 HotKeyEdit::HotKeyEdit( QWidget * parent ):
   QLineEdit( parent ),
-  currentModifiers( 0 ), currentKey1( 0 ), currentKey2( 0 ),
+  currentModifiers(), currentKey1( 0 ), currentKey2( 0 ),
   continuingCombo( false )
 {
   renderCurrentValue();
@@ -87,7 +87,7 @@ void HotKeyEdit::keyPressEvent( QKeyEvent * event )
         // Delete current combo
         currentKey1 = 0;
         currentKey2 = 0;
-        currentModifiers = 0;
+        currentModifiers = Qt::KeyboardModifiers();
         continuingCombo = false;
       }
       else

--- a/mainstatusbar.cc
+++ b/mainstatusbar.cc
@@ -43,7 +43,11 @@ MainStatusBar::MainStatusBar( QWidget *parent ) : QWidget( parent )
 
 bool MainStatusBar::hasImage() const
 {
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 15, 0 )
+  return !picWidget->pixmap( Qt::ReturnByValue ).isNull();
+#else
   return !picWidget->pixmap()->isNull();
+#endif
 }
 
 void MainStatusBar::clearMessage()
@@ -92,7 +96,7 @@ void MainStatusBar::refresh()
   {
     adjustSize();
 
-    if ( !picWidget->pixmap()->isNull() )
+    if ( hasImage() )
     {
       picWidget->setFixedSize( textWidget->height(), textWidget->height() );
     }

--- a/maintabwidget.cc
+++ b/maintabwidget.cc
@@ -2,6 +2,7 @@
  * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
 
 #include "maintabwidget.hh"
+#include "qt4x5.hh"
 #include <QDebug>
 #include <QEvent>
 #include <QMouseEvent>
@@ -67,7 +68,7 @@ bool MainTabWidget::eventFilter( QObject * obj, QEvent * ev )
   if( obj == tabBar() && ev->type() == QEvent::MouseButtonPress )
   {
      QMouseEvent * mev = static_cast< QMouseEvent *>( ev );
-     if( mev->button() == Qt::MidButton )
+     if( mev->button() == Qt4x5::middleButton() )
      {
          emit tabCloseRequested( tabBar()->tabAt( mev->pos() ) );
          return true;

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -1008,7 +1008,7 @@ void MainWindow::mousePressEvent( QMouseEvent *event)
     return;
   }
 
-  if (event->button() != Qt::MidButton)
+  if( event->button() != Qt4x5::middleButton() )
     return QMainWindow::mousePressEvent(event);
 
   // middle clicked

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -4546,7 +4546,7 @@ void MainWindow::editDictionary( Dictionary::Class * dict )
       QString headword = unescapeTabHeader( ui.tabWidget->tabText( ui.tabWidget->currentIndex() ) );
       command.replace( "%GDWORD%", headword );
     }
-    if( !QProcess::startDetached( command ) )
+    if( !Qt4x5::Process::startDetached( command ) )
       QApplication::beep();
   }
 }

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -1229,11 +1229,16 @@ void MainWindow::wheelEvent( QWheelEvent *ev )
 {
   if ( ev->modifiers().testFlag( Qt::ControlModifier ) )
   {
-    if ( ev->delta() > 0 )
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 0, 0 )
+    int const delta = ev->angleDelta().y();
+#else
+    int const delta = ev->delta();
+#endif
+    if ( delta > 0 )
     {
         zoomin();
     }
-    else if ( ev->delta() < 0 )
+    else if ( delta < 0 )
     {
         zoomout();
     }

--- a/mainwindow.hh
+++ b/mainwindow.hh
@@ -532,7 +532,7 @@ class ArticleSaveProgressDialog : public QProgressDialog
 Q_OBJECT
 
 public:
-  explicit ArticleSaveProgressDialog( QWidget * parent = 0,  Qt::WindowFlags f = 0 ):
+  explicit ArticleSaveProgressDialog( QWidget * parent = 0,  Qt::WindowFlags f = Qt::WindowFlags() ):
     QProgressDialog( parent, f )
   {
     setAutoReset( false );

--- a/mdictparser.cc
+++ b/mdictparser.cc
@@ -41,6 +41,7 @@
 #include "decompress.hh"
 #include "gddebug.hh"
 #include "ripemd.hh"
+#include "qt4x5.hh"
 
 namespace Mdict
 {
@@ -389,7 +390,7 @@ bool MdictParser::readHeader( QDataStream & in )
   {
     QString styleSheets = headerAttributes.namedItem( "StyleSheet" ).toAttr().value();
 #if QT_VERSION >= QT_VERSION_CHECK( 5, 0, 0 )
-    QStringList lines = styleSheets.split( QRegularExpression( "[\r\n]" ), QString::KeepEmptyParts );
+    QStringList lines = styleSheets.split( QRegularExpression( "[\r\n]" ), Qt4x5::keepEmptyParts() );
 #else
     QStringList lines = styleSheets.split( QRegExp( "[\r\n]" ), QString::KeepEmptyParts );
 #endif

--- a/preferences.cc
+++ b/preferences.cc
@@ -6,6 +6,37 @@
 #include "broken_xrecord.hh"
 #include "mainwindow.hh"
 
+#include <algorithm>
+#include <vector>
+
+namespace {
+struct ComboBoxItem
+{
+  QIcon icon;
+  QString text;
+  QString userData;
+
+  explicit ComboBoxItem( QString const & languageCode, QString const & countryCode, QString const & userData_ ):
+    icon( QString( ":/flags/%1.png" ).arg( countryCode ) ),
+    text( Language::localizedNameForId( LangCoder::code2toInt( languageCode.toLatin1().data() ) ) ),
+    userData( userData_ )
+  {}
+};
+
+bool operator<( ComboBoxItem const & a, ComboBoxItem const & b )
+{
+  return a.text < b.text;
+}
+
+void orderAndAddItems( QComboBox & comboBox, std::vector< ComboBoxItem > & items )
+{
+  // Sort by language name, because otherwise the list looks really weird.
+  std::sort( items.begin(), items.end() );
+  for( std::vector< ComboBoxItem >::iterator i = items.begin(); i != items.end(); ++i )
+    comboBox.addItem( i->icon, i->text, i->userData );
+}
+
+} // unnamed namespace
 
 Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
   QDialog( parent ), prevInterfaceLanguage( 0 )
@@ -66,8 +97,8 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
   QStringList availLocs = QDir( Config::getLocDir() ).entryList( QStringList( "*.qm" ),
                                                                  QDir::Files );
 
-  // We need to sort by language name -- otherwise list looks really weird
-  QMap< QString, QPair< QIcon, QString > > sortedLocs;
+  std::vector< ComboBoxItem > locs;
+  locs.reserve( availLocs.size() );
 
   for( QStringList::iterator i = availLocs.begin(); i != availLocs.end(); ++i )
   {
@@ -77,16 +108,10 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
     if ( lang == "qt" )
       continue; // We skip qt's own localizations
 
-    sortedLocs.insertMulti(
-      Language::localizedNameForId( LangCoder::code2toInt( lang.toLatin1().data() ) ),
-      QPair< QIcon, QString >(
-        QIcon( QString( ":/flags/%1.png" ).arg( i->mid( 3, 2 ).toLower() ) ),
-        i->mid( 0, i->size() - 3 ) ) );
+    locs.push_back( ComboBoxItem( lang, i->mid( 3, 2 ).toLower(), i->mid( 0, i->size() - 3 ) ) );
   }
 
-  for( QMap< QString, QPair< QIcon, QString > >::iterator i = sortedLocs.begin();
-       i != sortedLocs.end(); ++i )
-    ui.interfaceLanguage->addItem( i.value().first, i.key(), i.value().second );
+  orderAndAddItems( *ui.interfaceLanguage, locs );
 
   for( int x = 0; x < ui.interfaceLanguage->count(); ++x )
     if ( ui.interfaceLanguage->itemData( x ).toString() == p.interfaceLanguage )
@@ -105,7 +130,8 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
   QStringList availHelps = QDir( Config::getHelpDir() ).entryList( QStringList( "*.qch" ),
                                                                  QDir::Files );
 
-  QMap< QString, QPair< QIcon, QString > > sortedHelps;
+  std::vector< ComboBoxItem > helps;
+  helps.reserve( availHelps.size() );
 
   for( QStringList::iterator i = availHelps.begin(); i != availHelps.end(); ++i )
   {
@@ -122,15 +148,10 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
         reg = lang.toUpper();
     }
 
-    sortedHelps.insertMulti(
-      Language::localizedNameForId( LangCoder::code2toInt( lang.toLatin1().data() ) ),
-      QPair< QIcon, QString >(
-        QIcon( QString( ":/flags/%1.png" ).arg( reg.toLower() ) ), lang + "_" + reg ) );
+    helps.push_back( ComboBoxItem( lang, reg.toLower(), lang + "_" + reg ) );
   }
 
-  for( QMap< QString, QPair< QIcon, QString > >::iterator i = sortedHelps.begin();
-       i != sortedHelps.end(); ++i )
-    ui.helpLanguage->addItem( i.value().first, i.key(), i.value().second );
+  orderAndAddItems( *ui.helpLanguage, helps );
 
   for( int x = 0; x < ui.helpLanguage->count(); ++x )
     if ( ui.helpLanguage->itemData( x ).toString() == p.helpLanguage )

--- a/qt4x5.hh
+++ b/qt4x5.hh
@@ -34,6 +34,15 @@ inline QString::SplitBehavior skipEmptyParts()
 { return QString::SkipEmptyParts; }
 #endif
 
+inline Qt::MouseButton middleButton()
+{
+#if QT_VERSION >= QT_VERSION_CHECK( 4, 7, 0 )
+  return Qt::MiddleButton;
+#else
+  return Qt::MidButton;
+#endif
+}
+
 inline QString escape( QString const & plain )
 {
 #if IS_QT_5

--- a/qt4x5.hh
+++ b/qt4x5.hh
@@ -9,6 +9,7 @@
 # define IS_QT_5    1
 #endif
 
+#include <QProcess>
 #include <QString>
 #include <QAtomicInt>
 #include <QTextDocument>
@@ -187,6 +188,24 @@ typedef int size_type;
 #else
 typedef uint size_type;
 #endif
+
+}
+
+namespace Process
+{
+
+inline bool startDetached( QString const & command )
+{
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 15, 0 )
+  auto args = QProcess::splitCommand( command );
+  if( args.empty() )
+    return false;
+  auto const program = args.takeFirst();
+  return QProcess::startDetached( program, args );
+#else
+  return QProcess::startDetached( command );
+#endif
+}
 
 }
 

--- a/qt4x5.hh
+++ b/qt4x5.hh
@@ -22,9 +22,13 @@ namespace Qt4x5
 {
 
 #if QT_VERSION >= QT_VERSION_CHECK( 5, 14, 0 )
+inline Qt::SplitBehaviorFlags keepEmptyParts()
+{ return Qt::KeepEmptyParts; }
 inline Qt::SplitBehaviorFlags skipEmptyParts()
 { return Qt::SkipEmptyParts; }
 #else
+inline QString::SplitBehavior keepEmptyParts()
+{ return QString::KeepEmptyParts; }
 inline QString::SplitBehavior skipEmptyParts()
 { return QString::SkipEmptyParts; }
 #endif

--- a/scanflag.cc
+++ b/scanflag.cc
@@ -4,6 +4,10 @@
 #include "scanflag.hh"
 #include "ui_scanflag.h"
 
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 11, 0 )
+#include <QScreen>
+#endif
+
 static Qt::WindowFlags popupWindowFlags =
 
 Qt::ToolTip | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint
@@ -55,7 +59,11 @@ void ScanFlag::showScanFlag()
 
   QPoint currentPos = QCursor::pos();
 
-  QRect desktop = QApplication::desktop()->screenGeometry();
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 11, 0 )
+  QRect const desktop = QGuiApplication::primaryScreen()->geometry();
+#else
+  QRect const desktop = QApplication::desktop()->screenGeometry();
+#endif
 
   QSize windowSize = geometry().size();
 

--- a/scanpopup.cc
+++ b/scanpopup.cc
@@ -12,6 +12,10 @@
 #include "gddebug.hh"
 #include "gestures.hh"
 
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 11, 0 )
+#include <QScreen>
+#endif
+
 #ifdef Q_OS_MAC
 #include "macmouseover.hh"
 #define MouseOver MacMouseOver
@@ -634,7 +638,11 @@ void ScanPopup::engagePopup( bool forcePopup, bool giveFocus )
 
       QPoint currentPos = QCursor::pos();
 
-      QRect desktop = QApplication::desktop()->screenGeometry();
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 11, 0 )
+      QRect const desktop = QGuiApplication::primaryScreen()->geometry();
+#else
+      QRect const desktop = QApplication::desktop()->screenGeometry();
+#endif
 
       QSize windowSize = geometry().size();
 

--- a/sources.cc
+++ b/sources.cc
@@ -74,7 +74,11 @@ Sources::Sources( QWidget * parent, Config::Class const & cfg):
   ui.programs->resizeColumnToContents( 0 );
   // Make sure this thing will be large enough
   ui.programs->setColumnWidth( 1,
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 11, 0 )
+    QFontMetrics( QFont() ).horizontalAdvance(
+#else
     QFontMetrics( QFont() ).width(
+#endif
       ProgramTypeEditor::getNameForType( Config::Program::PrefixMatch ) ) + 16 );
   ui.programs->resizeColumnToContents( 2 );
   ui.programs->resizeColumnToContents( 3 );

--- a/website.cc
+++ b/website.cc
@@ -481,7 +481,10 @@ sptr< DataRequest > WebSiteDictionary::getArticle( wstring const & str,
     {
       codec = QTextCodec::codecForName( QString( "ISO 8859-%1" ).arg( x ).toLatin1() );
       if( codec )
-        urlString.replace( QString( "%25GDISO%1%25" ).arg( x ), codec->fromUnicode( inputWord ).toPercentEncoding() );
+      {
+        urlString.replace( QString( "%25GDISO%1%25" ).arg( x ).toLatin1(),
+                           codec->fromUnicode( inputWord ).toPercentEncoding() );
+      }
 
       if ( x == 10 )
         x = 12; // Skip encodings 11..12, they don't exist


### PR DESCRIPTION
I have smoke-tested most of the touched functionality and haven't noticed any regressions. 

The remaining, not fixed GCC warnings:
1. Deprecated ffmpeg API used in *ffmpegaudio.cc*.
2. Deprecated `uint32` and `uint16` type aliases declared in system *tiff.h* on GNU/Linux and used in *tiff.cc*.
3. Deprecated `QMutex::RecursionMode` used in *mutex.hh*. Fixing this warning flood is discussed in #1590. Since the MDX video cache workaround that requires a recursive mutex is not needed when GoldenDict is built against Qt WebEngine, I decided to make the mutex non-recursive in my Qt WebEngine version and disable the warning in the Qt WebKit version: https://github.com/vedgy/goldendict/commit/8a04dc8e004151470ba44aa3da0fdc72da895895.