### PR TITLE
Implement url schema handler for linux

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -143,7 +143,20 @@ public:
   { return !word.isEmpty(); }
 
   inline QString wordToTranslate()
-  { return word; }
+  { 
+#if defined( Q_OS_LINUX )
+    // handle url scheme like "goldendict://" or "dict://" on linux
+    auto schemePos = word.indexOf( "://" );
+    if ( schemePos != -1 ) {
+      word.remove( 0, schemePos + 3 );
+      // In microsoft Words, the / will be automatically appended
+      if ( word.endsWith( "/" ) ) {
+        word.chop( 1 );
+      }
+    }
+#endif
+    return word;
+  }
 };
 
 GDCommandLine::GDCommandLine( int argc, char **argv ):

--- a/redist/org.goldendict.GoldenDict.desktop
+++ b/redist/org.goldendict.GoldenDict.desktop
@@ -6,4 +6,5 @@ Name=GoldenDict
 GenericName=Multiformat Dictionary
 Comment=A feature-rich dictionary lookup program
 Icon=goldendict
-Exec=goldendict
+Exec=goldendict %u
+MimeType=x-scheme-handler/goldendict;x-scheme-handler/dict;


### PR DESCRIPTION
Enable links like `goldndict://word`

Borrowed from https://github.com/xiaoyifang/goldendict-ng/pull/227

related https://github.com/goldendict/goldendict/issues/735
related https://github.com/goldendict/goldendict/issues/1139
related https://github.com/goldendict/goldendict/issues/1280
related https://github.com/goldendict/goldendict/issues/1139

Related specs:

https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html
https://specifications.freedesktop.org/shared-mime-info-spec/shared-mime-info-spec-latest.html

The cache database of MIME types handled by desktop files must be updated.

And it works :unicorn: :fire: :100: :1st_place_medal: 