### PR TITLE
Streamline code formatting.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,145 @@
+---
+Language: Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: Consecutive
+AlignConsecutiveDeclarations: None
+AlignConsecutiveMacros: Consecutive
+AlignEscapedNewlines: Left
+AlignOperands: DontAlign
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortLambdasOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AllowShortEnumsOnASingleLine: false
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: true
+  AfterControlStatement: Never
+  AfterEnum: false
+  AfterFunction: true
+  AfterNamespace: false
+  AfterObjCDeclaration: false
+  AfterStruct: true
+  AfterUnion: true
+  AfterExternBlock: false
+  BeforeCatch: true
+  BeforeElse: true
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+  BeforeLambdaBody: false
+  BeforeWhile: false
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: AfterColon
+BreakStringLiterals: false
+ColumnLimit: 120
+QualifierAlignment: Leave
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth : 2
+ContinuationIndentWidth: 2
+Cpp11BracedListStyle: true
+DeriveLineEnding: false
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Leave
+EmptyLineBeforeAccessModifier: Always
+ExperimentalAutoDetectBinPacking: true
+AllowAllConstructorInitializersOnNextLine: true
+FixNamespaceComments: true
+ForEachMacros:
+  - Q_FOREACH
+IncludeBlocks: Regroup
+IndentCaseLabels: true
+IndentAccessModifiers: false
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentRequiresClause: true
+IndentWidth: 2
+IndentWrappedFunctionNames: false
+InsertBraces: false
+InsertTrailingCommas: None
+KeepEmptyLinesAtTheStartOfBlocks: true
+LambdaBodyIndentation: Signature
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: None
+PackConstructorInitializers: Never
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Middle
+PPIndentWidth:   -1
+ReferenceAlignment: Pointer
+ReflowComments: false
+SortIncludes: Never
+RequiresClausePosition: OwnLine
+RemoveBracesLLVM: false
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortUsingDeclarations: false
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: false
+SpaceBeforeInheritanceColon: false
+SpaceBeforeParens: ControlStatements
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: true
+SpacesInConditionalStatement: true
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum: 1
+  Maximum: -1
+SpacesInParentheses: true
+SpacesInSquareBrackets: true
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
+Standard: Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+UseCRLF: false
+UseTab: Never
+...

--- a/.clang-format
+++ b/.clang-format
@@ -6,8 +6,8 @@ AlignAfterOpenBracket: Align
 AlignArrayOfStructures: None
 AlignConsecutiveAssignments: None
 AlignConsecutiveBitFields: Consecutive
-AlignConsecutiveDeclarations: None
 AlignConsecutiveMacros: Consecutive
+AlignConsecutiveDeclarations: None
 AlignEscapedNewlines: Left
 AlignOperands: DontAlign
 AlignTrailingComments: true
@@ -29,7 +29,7 @@ BinPackParameters: false
 BraceWrapping:
   AfterCaseLabel: false
   AfterClass: true
-  AfterControlStatement: Never
+  AfterControlStatement: Always
   AfterEnum: false
   AfterFunction: true
   AfterNamespace: false


### PR DESCRIPTION
Borrowed from https://github.com/xiaoyifang/goldendict-ng/blob/staged/.clang-format

The style is adjusted to minimize how much code will be changed if run clang-format over the entire code base.

close: https://github.com/goldendict/goldendict/issues/1454

All new codes should follow this.

![image](https://user-images.githubusercontent.com/20123683/235098714-f0bf170a-02bd-4942-b581-ab656fc6f720.png)

https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 

Fix those things:

![image](https://user-images.githubusercontent.com/20123683/235098974-5c17bbaf-2378-4c7b-b1fe-e0cf10b3ba6f.png)
![image](https://user-images.githubusercontent.com/20123683/235100907-bce6d57d-4787-4d02-b52b-ed594bd323c3.png)
![image](https://user-images.githubusercontent.com/20123683/235098424-7bf188dc-ef00-4515-b086-745db23f7adf.png)
![image](https://user-images.githubusercontent.com/20123683/235098519-24c431d4-a913-4e9e-a86a-6bd5457b0a35.png)
![image](https://user-images.githubusercontent.com/20123683/235098546-b06f74e8-c9d5-4460-bc94-75fd81414335.png)
![image](https://user-images.githubusercontent.com/20123683/235098330-04b595e4-198f-4dd5-ad84-11764cf1f997.png)
![image](https://user-images.githubusercontent.com/20123683/235099336-48cc5d99-05da-4947-a95e-714801c5361e.png)


https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 https://github.com/goldendict/goldendict/pull/1458 

![image](https://user-images.githubusercontent.com/20123683/235098714-f0bf170a-02bd-4942-b581-ab656fc6f720.png)



