### PR TITLE
Handle goldendict:// and dict:// URI schemes

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -34,6 +34,7 @@
 #include <QFile>
 #include <QByteArray>
 #include <QString>
+#include <QUrl>
 
 #include "gddebug.hh"
 
@@ -144,6 +145,9 @@ public:
 
   inline QString wordToTranslate()
   { return word; }
+
+private:
+  void setWord( QString const & word_ );
 };
 
 GDCommandLine::GDCommandLine( int argc, char **argv ):
@@ -196,8 +200,41 @@ logFile( false )
         continue;
       }
       else
-        word = arguments[ i ];
+        setWord( arguments[ i ] );
     }
+  }
+}
+
+void GDCommandLine::setWord( QString const & word_ )
+{
+  word = word_;
+
+  static QLatin1String const uriSchemes[] = { QLatin1String( "goldendict://" ),
+                                              QLatin1String( "dict://" ) };
+  static size_t const uriSchemeCount = sizeof( uriSchemes ) / sizeof( uriSchemes[ 0 ] );
+  for( size_t i = 0; i < uriSchemeCount; ++i )
+  {
+    QLatin1String const scheme = uriSchemes[ i ];
+    if( !word.startsWith( scheme ) )
+      continue;
+
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 0, 0 )
+    int schemeSize = scheme.size();
+#else
+    int schemeSize = strlen( scheme.latin1() );
+#endif
+    if( word.size() > schemeSize && word.at( schemeSize ) == QLatin1Char( '/' ) )
+      ++schemeSize; // support dict:///word as well
+
+    word.remove( 0, schemeSize );
+
+    // An URI can end with a trailing slash, which has to be removed here. This should be more common
+    // than a deliberate lookup of the slash character or a string that ends with a slash.
+    // If word equals '/' (size 1), then word_ ends with 4 slashes, in which case translate the slash.
+    if( word.size() > 1 && word.at( word.size() - 1 ) == QLatin1Char( '/' ) )
+      word.chop( 1 );
+
+    word = QUrl::fromPercentEncoding( word.toUtf8() );
   }
 }
 

--- a/redist/org.goldendict.GoldenDict.desktop
+++ b/redist/org.goldendict.GoldenDict.desktop
@@ -6,4 +6,5 @@ Name=GoldenDict
 GenericName=Multiformat Dictionary
 Comment=A feature-rich dictionary lookup program
 Icon=goldendict
-Exec=goldendict
+Exec=goldendict %u
+MimeType=x-scheme-handler/goldendict;x-scheme-handler/dict;


### PR DESCRIPTION
Specifications:
https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html https://specifications.freedesktop.org/shared-mime-info-spec/shared-mime-info-spec-latest.html#idm45659000071008

GoldenDict now opens the supported URIs on GNU/Linux. However, platform-specific changes may be necessary to make this work on other operating systems. Hopefully the required changes can be implemented without recompiling GoldenDict, similarly to the simple modification of GoldenDict's desktop file in this commit. In this case, a user can make the necessary changes and test locally, then create a pull request to complete URI scheme support on his/her preferred OS.

This feature has been requested in #735, #1139 and #1280. The implementation is based on #1624 and its review in #1625.