### PR TITLE
Allow building against libebu in place of libeb

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ If you have problem building with libeb-dev package, you can pass
 
     qmake "CONFIG+=no_epwing_support"
 
+### Building against libebu in place of libeb
+
+[libebu](http://green.ribbon.to/~ikazuhiro/dic/ebu.html) claims to be a modern replacement for libeb.
+Among other things, it supports UTF-8 extension in addition to EUC-JP.
+If you want to build GoldenDict against libebu, pass `"CONFIG+=use_libebu"` to `qmake`:
+
+    qmake "CONFIG+=use_libebu"
+
 ### Building without internal audio players
 
 If you have problem building with FFmpeg/libao (for example, Ubuntu older than 12.04), you can pass

--- a/epwing_book.cc
+++ b/epwing_book.cc
@@ -18,11 +18,19 @@
 #define _FILE_OFFSET_BITS 64
 #endif
 
+#ifdef USE_LIBEBU
+#include <ebu/text.h>
+#include <ebu/appendix.h>
+#include <ebu/error.h>
+#include <ebu/binary.h>
+#include <ebu/font.h>
+#else
 #include <eb/text.h>
 #include <eb/appendix.h>
 #include <eb/error.h>
 #include <eb/binary.h>
 #include <eb/font.h>
+#endif
 
 #define HitsBufferSize 512
 

--- a/epwing_book.hh
+++ b/epwing_book.hh
@@ -22,7 +22,11 @@
 #include <stub_msvc.h>
 #endif
 
+#ifdef USE_LIBEBU
+#include <ebu/eb.h>
+#else
 #include <eb/eb.h>
+#endif
 
 namespace Epwing {
 

--- a/goldendict.pro
+++ b/goldendict.pro
@@ -576,7 +576,12 @@ CONFIG( no_epwing_support ) {
   SOURCES += epwing.cc \
              epwing_book.cc \
              epwing_charmap.cc
-  LIBS += -leb
+  CONFIG( use_libebu ) {
+    DEFINES += USE_LIBEBU
+    LIBS += -lebu
+  } else {
+    LIBS += -leb
+  }
 }
 
 CONFIG( chinese_conversion_support ) {


### PR DESCRIPTION
This commit is based on the first commit of an unmerged porting pull request #1344. As I wrote in a comment to that pull request, the first step in porting from libeb to libebu is to allow optionally building GoldenDict against libebu and let GNU/Linux distributions try switching to libebu, if they feel like it. Then the distros' experience and bug reports (or lack thereof) can help us decide whether to make libebu the default dependency and whether to replace GoldenDict's bundled libeb files with the corresponding libebu files in maclibs/ and winlibs/.