### PR TITLE
Fix scanpopup being shown across multiple monitors

### DIFF
--- a/scanpopup.cc
+++ b/scanpopup.cc
@@ -639,7 +639,7 @@ void ScanPopup::engagePopup( bool forcePopup, bool giveFocus )
       QPoint currentPos = QCursor::pos();
 
 #if QT_VERSION >= QT_VERSION_CHECK( 5, 11, 0 )
-      QRect const desktop = QGuiApplication::primaryScreen()->geometry();
+      QRect const desktop = QGuiApplication::screenAt(currentPos)->geometry();
 #else
       QRect const desktop = QApplication::desktop()->screenGeometry();
 #endif


### PR DESCRIPTION
When opening the scan popup close to another monitor it will be shown across both, which makes it unreadable. Fixes #51 