### PR TITLE
Qt5.11+: Fix scanpopup/-flag with multiple monitors

### DIFF
--- a/scanflag.cc
+++ b/scanflag.cc
@@ -60,7 +60,7 @@ void ScanFlag::showScanFlag()
   QPoint currentPos = QCursor::pos();
 
 #if QT_VERSION >= QT_VERSION_CHECK( 5, 11, 0 )
-  QRect const desktop = QGuiApplication::primaryScreen()->geometry();
+  QRect const desktop = QGuiApplication::screenAt( currentPos )->geometry();
 #else
   QRect const desktop = QApplication::desktop()->screenGeometry();
 #endif

--- a/scanpopup.cc
+++ b/scanpopup.cc
@@ -639,7 +639,7 @@ void ScanPopup::engagePopup( bool forcePopup, bool giveFocus )
       QPoint currentPos = QCursor::pos();
 
 #if QT_VERSION >= QT_VERSION_CHECK( 5, 11, 0 )
-      QRect const desktop = QGuiApplication::primaryScreen()->geometry();
+      QRect const desktop = QGuiApplication::screenAt( currentPos )->geometry();
 #else
       QRect const desktop = QApplication::desktop()->screenGeometry();
 #endif


### PR DESCRIPTION
Opening the scanpopup/-flag close to a monitor boundary results in the popup/flag either being shown across both monitors or it quickly disappearing, which makes it unusable.

Fixes #51