### PR TITLE
Set fallback version to 1.5.0+git (not RC2)

### DIFF
--- a/goldendict.pro
+++ b/goldendict.pro
@@ -1,6 +1,6 @@
 TEMPLATE = app
 TARGET = goldendict
-VERSION = 1.5.0-RC2+git
+VERSION = 1.5.0+git
 
 # Generate version file. We do this here and in a build rule described later.
 # The build rule is required since qmake isn't run each time the project is


### PR DESCRIPTION
GoldenDict 1.5.0 is about to be tagged, which would obsolete the "-RC2" part of the version.

This reverts commit b6622271b61af466bb58c2ed464556baea6a5a90.

--------------

**Note:** once this pull request is merged, I'll push an annotated tag `1.5.0`. The tag will fix the issue #839.