### PR TITLE
Prepare Lojban .ts file for Qt5's lupdate

### DIFF
--- a/locale/jb_JB.ts
+++ b/locale/jb_JB.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0" language="jb">
+<TS version="2.0" language="ja">
 <context>
     <name>About</name>
     <message>


### PR DESCRIPTION
This commit eliminates the following warning in the output of command `lupdate goldendict.pro`:
>  File /path/to/goldendict/locale/jb_JB.ts won't be updated: it contains translation but the target language is not recognized

The issue was introduced in Qt 5.13 and cherry-picked into Qt 5.12.4: https://codereview.qt-project.org/c/qt/qttools/+/255003

The .ts file is not updated, because the Lojban language is absent from Qt's numerusTable in qttools/src/linguist/shared/numerus.cpp.

Work the issue around by setting the language attribute of the TS element to a suitable supported language code "ja" (Japanese). Words in Lojban do not actually have a separate plural form, like in Japanese. So this way plural translations should be handled correctly.

Closes #1642