### PR TITLE
MacOS: Fix calling the Help window from F3 and F4 dialogs

### DIFF
--- a/editdictionaries.cc
+++ b/editdictionaries.cc
@@ -271,12 +271,19 @@ void EditDictionaries::helpRequested()
 
     if( helpWindow )
     {
-      helpWindow->setWindowFlags( Qt::Window );
+      #ifdef Q_OS_MAC
+        helpWindow->setWindowFlags( Qt::Dialog );
+      #else
+        helpWindow->setWindowFlags( Qt::Window );
+      #endif
 
       connect( helpWindow, SIGNAL( needClose() ),
                this, SLOT( closeHelp() ) );
       helpWindow->showHelpFor( "Manage dictionaries" );
       helpWindow->show();
+      #ifdef Q_OS_MAC
+        helpWindow->activateWindow();
+      #endif
     }
   }
   else

--- a/preferences.cc
+++ b/preferences.cc
@@ -701,12 +701,19 @@ void Preferences::helpRequested()
 
     if( helpWindow )
     {
-      helpWindow->setWindowFlags( Qt::Window );
+      #ifdef Q_OS_MAC
+        helpWindow->setWindowFlags( Qt::Dialog );
+      #else
+        helpWindow->setWindowFlags( Qt::Window );
+      #endif
 
       connect( helpWindow, SIGNAL( needClose() ),
                this, SLOT( closeHelp() ) );
       helpWindow->showHelpFor( "Preferences" );
       helpWindow->show();
+      #ifdef Q_OS_MAC
+        helpWindow->activateWindow();
+      #endif
     }
   }
   else


### PR DESCRIPTION
This is specific to macOS only. When you invoke Help from the `F3` and `⌘,` (`F4`) dialogs, the Help window becomes inactive and inaccessible.  This fix corrects the problem. Tested on Mojave 10.14.6 and Big Sur 11.7.