### PR TITLE
Update article link converting for stardict

### DIFF
--- a/stardict.cc
+++ b/stardict.cc
@@ -467,25 +467,21 @@ string StardictDictionary::handleResource( char type, char const * resource, siz
       QString articleText = QString( "<div class=\"sdct_h\">" ) + QString::fromUtf8( resource, size ) + "</div>";
 
       const QString srcRegexpStr(
-          "(<\\s*img\\s+[^>]*src\\s*=\\s*[\"']+)(?!(?:data|https?|ftp):)" );
+          "(<\\s*(?:img|script)\\s(?:[^>]*\\s)?src\\s*=)(?!\\s*[\"']?(?:data|https?|ftp):)(\\s*[\"']?)" );
       const QString linkRegexpStr(
-          "(<\\s*link\\s+[^>]*href\\s*=\\s*[\"']+)(?!(?:data|https?|ftp):)" );
+          "(<\\s*link\\s(?:[^>]*\\s)?href\\s*=)(?!\\s*[\"']?(?:data|https?|ftp):)(\\s*[\"']?)" );
 #if QT_VERSION >= QT_VERSION_CHECK( 5, 0, 0 )
       QRegularExpression srcRe( srcRegexpStr,
-                                QRegularExpression::CaseInsensitiveOption
-                                | QRegularExpression::InvertedGreedinessOption );
+                                QRegularExpression::CaseInsensitiveOption );
       QRegularExpression linkRe( linkRegexpStr,
-                                 QRegularExpression::CaseInsensitiveOption
-                                 | QRegularExpression::InvertedGreedinessOption );
+                                 QRegularExpression::CaseInsensitiveOption );
 #else
       QRegExp srcRe( srcRegexpStr, Qt::CaseInsensitive );
-      imgRe.setMinimal( true );
       QRegExp linkRe( linkRegexpStr, Qt::CaseInsensitive );
-      linkRe.setMinimal( true );
 #endif
 
-      articleText.replace( srcRe, "\\1bres://" + QString::fromStdString( getId() ) + "/" )
-                 .replace( linkRe, "\\1bres://" + QString::fromStdString( getId() ) + "/" );
+      articleText.replace( srcRe, "\\1\\2bres://" + QString::fromStdString( getId() ) + "/" )
+                 .replace( linkRe, "\\1\\2bres://" + QString::fromStdString( getId() ) + "/" );
 
       // Handle links to articles
 

--- a/stardict.cc
+++ b/stardict.cc
@@ -466,21 +466,25 @@ string StardictDictionary::handleResource( char type, char const * resource, siz
     {
       QString articleText = QString( "<div class=\"sdct_h\">" ) + QString::fromUtf8( resource, size ) + "</div>";
 
+      const QString srcRegexpStr(
+          "(<\\s*img\\s+[^>]*src\\s*=\\s*[\"']+)(?!(?:data|https?|ftp):)" );
+      const QString linkRegexpStr(
+          "(<\\s*link\\s+[^>]*href\\s*=\\s*[\"']+)(?!(?:data|https?|ftp):)" );
 #if QT_VERSION >= QT_VERSION_CHECK( 5, 0, 0 )
-      QRegularExpression imgRe( "(<\\s*img\\s+[^>]*src\\s*=\\s*[\"']+)(?!(?:data|https?|ftp):)",
+      QRegularExpression srcRe( srcRegexpStr,
                                 QRegularExpression::CaseInsensitiveOption
                                 | QRegularExpression::InvertedGreedinessOption );
-      QRegularExpression linkRe( "(<\\s*link\\s+[^>]*href\\s*=\\s*[\"']+)(?!(?:data|https?|ftp):)",
+      QRegularExpression linkRe( linkRegexpStr,
                                  QRegularExpression::CaseInsensitiveOption
                                  | QRegularExpression::InvertedGreedinessOption );
 #else
-      QRegExp imgRe( "(<\\s*img\\s+[^>]*src\\s*=\\s*[\"']+)(?!(?:data|https?|ftp):)", Qt::CaseInsensitive );
+      QRegExp srcRe( srcRegexpStr, Qt::CaseInsensitive );
       imgRe.setMinimal( true );
-      QRegExp linkRe( "(<\\s*link\\s+[^>]*href\\s*=\\s*[\"']+)(?!(?:data|https?|ftp):)", Qt::CaseInsensitive );
+      QRegExp linkRe( linkRegexpStr, Qt::CaseInsensitive );
       linkRe.setMinimal( true );
 #endif
 
-      articleText.replace( imgRe , "\\1bres://" + QString::fromStdString( getId() ) + "/" )
+      articleText.replace( srcRe, "\\1bres://" + QString::fromStdString( getId() ) + "/" )
                  .replace( linkRe, "\\1bres://" + QString::fromStdString( getId() ) + "/" );
 
       // Handle links to articles


### PR DESCRIPTION
PR fixes two minor links matching issues I had met:
  - Expressions did not match HTML attributes with omitted quotes which is a case of minimized HTML. Now match correctly with no false-positives.
  - Expressions did not process `<script src=...>` tags. Now expression for `img` tag matches also `script` tag.