### PR TITLE
Set application version to 1.5.1

### DIFF
--- a/goldendict.pro
+++ b/goldendict.pro
@@ -1,6 +1,6 @@
 TEMPLATE = app
 TARGET = goldendict
-VERSION = 1.5.0+git
+VERSION = 1.5.1+git
 
 # Generate version file. We do this here and in a build rule described later.
 # The build rule is required since qmake isn't run each time the project is
@@ -72,7 +72,7 @@ win32 {
     TARGET = GoldenDict
 
     win32-msvc* {
-        VERSION = 1.5.0 # More complicated things cause errors during compilation under MSVC++
+        VERSION = 1.5.1 # More complicated things cause errors during compilation under MSVC++
         DEFINES += __WIN32 _CRT_SECURE_NO_WARNINGS
         contains(QMAKE_TARGET.arch, x86_64) {
             DEFINES += NOMINMAX __WIN64

--- a/goldendict.rc
+++ b/goldendict.rc
@@ -2,8 +2,8 @@
 
 IDI_ICON1 ICON DISCARDABLE "icons/programicon.ico"
 IDI_ICON2 ICON DISCARDABLE "icons/programicon_old.ico"
-#define GOLDENDICT_VER 1,5,0,0
-#define GOLDENDICT_VER_STR "1.5.0"
+#define GOLDENDICT_VER 1,5,1,0
+#define GOLDENDICT_VER_STR "1.5.1"
 
 #if !defined( _MSC_VER ) && !defined( GD_NO_MANIFEST ) // Visual Studio embeds the manifest automatically
 1 RT_MANIFEST GoldenDict.exe.manifest


### PR DESCRIPTION
GoldenDict version 1.5.1 is about to be tagged.

-----------------
**Note**: once this pull request is merged, I'll push an annotated tag 1.5.1.

A GitHub release should be created to improve the visibility and simplify downloading the new release binaries. @Abs62, would you be willing to attach Windows builds for the new tag to a GitHub release?